### PR TITLE
chore: promote nodey545 to version 1.0.1 in Production environment

### DIFF
--- a/config-root/namespaces/jx-production/nodey545/nodey545-1.0.1-release.yaml
+++ b/config-root/namespaces/jx-production/nodey545/nodey545-1.0.1-release.yaml
@@ -1,0 +1,49 @@
+# Source: nodey545/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-10T10:11:37Z"
+  deletionTimestamp: null
+  name: 'nodey545-1.0.1'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 1.0.1
+      sha: 5e09f11287f68843759ee3b6c31b88c4f95745b6
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 5a5926c40cd1482cab4d12136c3b8c4852057769
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      message: |
+        chore: Jenkins X build pack
+      sha: c7730637f441f9045297c1e20dccf8842e2d14b1
+  gitHttpUrl: https://github.com/jstrachan/nodey545
+  gitOwner: jstrachan
+  gitRepository: nodey545
+  name: 'nodey545'
+  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v1.0.1
+  version: v1.0.1
+status: {}

--- a/config-root/namespaces/jx-production/nodey545/nodey545-ingress.yaml
+++ b/config-root/namespaces/jx-production/nodey545/nodey545-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: nodey545/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: nodey545
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey545
+              servicePort: 80
+      host: nodey545-jx-production.34.105.246.143.nip.io

--- a/config-root/namespaces/jx-production/nodey545/nodey545-nodey545-deploy.yaml
+++ b/config-root/namespaces/jx-production/nodey545/nodey545-nodey545-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: nodey545/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodey545-nodey545
+  labels:
+    draft: draft-app
+    chart: "nodey545-1.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nodey545-nodey545
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: nodey545-nodey545
+    spec:
+      serviceAccountName: nodey545-nodey545
+      containers:
+        - name: nodey545
+          image: "gcr.io/jenkins-x-labs-bdd/nodey545:1.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 1.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/nodey545/nodey545-nodey545-sa.yaml
+++ b/config-root/namespaces/jx-production/nodey545/nodey545-nodey545-sa.yaml
@@ -1,0 +1,8 @@
+# Source: nodey545/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nodey545-nodey545
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/nodey545/nodey545-svc.yaml
+++ b/config-root/namespaces/jx-production/nodey545/nodey545-svc.yaml
@@ -1,0 +1,21 @@
+# Source: nodey545/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey545
+  labels:
+    chart: "nodey545-1.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey545-nodey545

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -1,19 +1,11 @@
 filepath: ""
 helmfiles:
 - path: helmfiles/cert-manager/helmfile.yaml
-  environment: {}
 - path: helmfiles/jx/helmfile.yaml
-  environment: {}
 - path: helmfiles/nginx/helmfile.yaml
-  environment: {}
 - path: helmfiles/secret-infra/helmfile.yaml
-  environment: {}
 - path: helmfiles/tekton-pipelines/helmfile.yaml
-  environment: {}
 - path: helmfiles/jx-staging/helmfile.yaml
-  environment: {}
 - path: helmfiles/jx-production/helmfile.yaml
-  environment: {}
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -1,10 +1,19 @@
 filepath: ""
 helmfiles:
 - path: helmfiles/cert-manager/helmfile.yaml
+  environment: {}
 - path: helmfiles/jx/helmfile.yaml
+  environment: {}
 - path: helmfiles/nginx/helmfile.yaml
+  environment: {}
 - path: helmfiles/secret-infra/helmfile.yaml
+  environment: {}
 - path: helmfiles/tekton-pipelines/helmfile.yaml
+  environment: {}
 - path: helmfiles/jx-staging/helmfile.yaml
+  environment: {}
+- path: helmfiles/jx-production/helmfile.yaml
+  environment: {}
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -1,4 +1,8 @@
 filepath: ""
+environments:
+  default:
+    values:
+    - jx-values.yaml
 namespace: jx-production
 repositories:
 - name: dev
@@ -7,8 +11,7 @@ releases:
 - chart: dev/nodey545
   version: 1.0.1
   name: nodey545
-  forceNamespace: ""
-  skipDeps: null
+  values:
+  - jx-values.yaml
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -1,0 +1,14 @@
+filepath: ""
+namespace: jx-production
+repositories:
+- name: dev
+  url: http://chartmuseum-jx.34.105.246.143.nip.io/
+releases:
+- chart: dev/nodey545
+  version: 1.0.1
+  name: nodey545
+  forceNamespace: ""
+  skipDeps: null
+templates: {}
+missingFileHandler: ""
+renderedvalues: {}

--- a/helmfiles/jx-production/jx-values.yaml
+++ b/helmfiles/jx-production/jx-values.yaml
@@ -1,0 +1,61 @@
+jx:
+  imagePullSecrets: []
+  secrets:
+    adminUser:
+      password: todo
+      username: todo
+    hmacToken: todo
+    pipelineUser:
+      email: jenkins-x@googlegroups.com
+      token: todo
+      username: jenkins-x-labs-bot
+jxRequirements:
+  autoUpdate:
+    enabled: false
+    schedule: ""
+  cluster:
+    chartRepository: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
+    clusterName: jstrachan-tekton2
+    environmentGitOwner: todo
+    gitKind: github
+    gitName: github
+    gitServer: https://github.com
+    gke:
+      projectNumber: "688875092189"
+    project: jenkins-x-labs-bdd
+    provider: gke
+    registry: gcr.io
+    zone: europe-west2-b
+  environments:
+  - key: dev
+    owner: jstrachan
+    repository: jx-demo-gke2-dev
+  - key: staging
+  - key: production
+  ingress:
+    domain: 34.105.246.143.nip.io
+    externalDNS: false
+    namespaceSubDomain: -jx-production.
+    tls:
+      email: ""
+      enabled: false
+      production: true
+  pipelineUser:
+    username: jstrachan
+  repository: nexus
+  secretStorage: gsm
+  storage:
+  - name: logs
+    url: gs://logs-jstrachan-tekton2-d3ca9654053a
+  - name: reports
+    url: gs://reports-jstrachan-tekton2-d3ca9654053a
+  - name: repository
+    url: gs://repository-jstrachan-tekton2-d3ca9654053a
+  vault: {}
+  webhook: lighthouse
+jxRequirementsIngressExternalDNS:
+  enabled: false
+jxRequirementsIngressTLS:
+  enabled: false
+jxRequirementsVault:
+  enabled: false


### PR DESCRIPTION
chore: promote nodey545 to version 1.0.1 in Production environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge