### PR TITLE
chore: promote nodey545 to version 1.0.3 in Staging environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ Now git commit and push any changes...
 git add *
 git commit -a -m "chore: Jenkins X changes"
 ```
+

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-1.0.3-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-1.0.3-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-10T10:11:37Z"
+  creationTimestamp: "2020-12-14T08:44:12Z"
   deletionTimestamp: null
-  name: 'nodey545-1.0.1'
+  name: 'nodey545-1.0.3'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.1
-      sha: 5e09f11287f68843759ee3b6c31b88c4f95745b6
+        chore: release 1.0.3
+      sha: 95faa226f8ddceba77ba9a9461a1005d6a44706e
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,21 +29,11 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 5a5926c40cd1482cab4d12136c3b8c4852057769
-    - author:
-        email: james.strachan@gmail.com
-        name: James Strachan
-      branch: master
-      committer:
-        email: james.strachan@gmail.com
-        name: James Strachan
-      message: |
-        chore: Jenkins X build pack
-      sha: c7730637f441f9045297c1e20dccf8842e2d14b1
+      sha: dd78e6132e2e86b310aa6da80aa2d53531fe3687
   gitHttpUrl: https://github.com/jstrachan/nodey545
   gitOwner: jstrachan
   gitRepository: nodey545
   name: 'nodey545'
-  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v1.0.1
-  version: v1.0.1
+  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v1.0.3
+  version: v1.0.3
 status: {}

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey545-nodey545
   labels:
     draft: draft-app
-    chart: "nodey545-1.0.1"
+    chart: "nodey545-1.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey545-nodey545
       containers:
         - name: nodey545
-          image: "gcr.io/jenkins-x-labs-bdd/nodey545:1.0.1"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey545:1.0.3"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.1
+              value: 1.0.3
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey545
   labels:
-    chart: "nodey545-1.0.1"
+    chart: "nodey545-1.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,8 +13,5 @@ releases:
   name: nodey545
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,9 +9,12 @@ repositories:
   url: http://chartmuseum-jx.34.105.246.143.nip.io/
 releases:
 - chart: dev/nodey545
-  version: 1.0.1
+  version: 1.0.3
   name: nodey545
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey545 to version 1.0.3 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge