### PR TITLE
chore: promote nodey545 to version 1.0.5 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey545/nodey545-1.0.5-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-1.0.5-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-14T08:59:39Z"
+  creationTimestamp: "2020-12-14T09:08:07Z"
   deletionTimestamp: null
-  name: 'nodey545-1.0.4'
+  name: 'nodey545-1.0.5'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.4
-      sha: 7dc6c81b322ae269af1dddbfd803e9de3dbf5332
+        chore: release 1.0.5
+      sha: 4abb0b77ad61d61e31b620509f5d9125aa042c1e
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 2d1d187e7e91db95fc1c169ecc1e8664956b0ca9
+      sha: 2bde8fb96c8e86cd0f8bba56841638f25c7e594f
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -38,12 +38,12 @@ spec:
         email: james.strachan@gmail.com
         name: James Strachan
       message: |
-        fix: add workflows
-      sha: a6e30dd05f36d043101ace79ff88282da0983d27
+        fix: upgrade actions
+      sha: ea573fd65068d49a25e9ce333291a4a70762ce37
   gitHttpUrl: https://github.com/jstrachan/nodey545
   gitOwner: jstrachan
   gitRepository: nodey545
   name: 'nodey545'
-  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v1.0.4
-  version: v1.0.4
+  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v1.0.5
+  version: v1.0.5
 status: {}

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey545-nodey545
   labels:
     draft: draft-app
-    chart: "nodey545-1.0.4"
+    chart: "nodey545-1.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey545-nodey545
       containers:
         - name: nodey545
-          image: "gcr.io/jenkins-x-labs-bdd/nodey545:1.0.4"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey545:1.0.5"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.4
+              value: 1.0.5
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey545
   labels:
-    chart: "nodey545-1.0.4"
+    chart: "nodey545-1.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,9 +9,12 @@ repositories:
   url: http://chartmuseum-jx.34.105.246.143.nip.io/
 releases:
 - chart: dev/nodey545
-  version: 1.0.4
+  version: 1.0.5
   name: nodey545
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,8 +13,5 @@ releases:
   name: nodey545
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey545 to version 1.0.5 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge