### PR TITLE
chore: promote nodey545 to version 1.0.8 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey545/nodey545-1.0.8-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-1.0.8-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-14T09:32:39Z"
+  creationTimestamp: "2020-12-14T09:35:19Z"
   deletionTimestamp: null
-  name: 'nodey545-1.0.7'
+  name: 'nodey545-1.0.8'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.7
-      sha: 6c8e69e939468b6f126ad7c4afb155b1100a7de9
+        chore: release 1.0.8
+      sha: 8aea78a9c5f86758ae95065f5309de198005017f
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 8c8ec0dfd0f15a863328792074300826180a0c20
+      sha: e20bebfa8429a868ce766aed088cbd98b36699db
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -39,11 +39,11 @@ spec:
         name: James Strachan
       message: |
         chore: regenerated
-      sha: 0ee047b61cda39ed4bc4c7f01f91fde3aa9abef5
+      sha: a96597177397cde150a1ea1a0bccdb842bdb5175
   gitHttpUrl: https://github.com/jstrachan/nodey545
   gitOwner: jstrachan
   gitRepository: nodey545
   name: 'nodey545'
-  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v1.0.7
-  version: v1.0.7
+  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v1.0.8
+  version: v1.0.8
 status: {}

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey545-nodey545
   labels:
     draft: draft-app
-    chart: "nodey545-1.0.7"
+    chart: "nodey545-1.0.8"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey545-nodey545
       containers:
         - name: nodey545
-          image: "gcr.io/jenkins-x-labs-bdd/nodey545:1.0.7"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey545:1.0.8"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.7
+              value: 1.0.8
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey545
   labels:
-    chart: "nodey545-1.0.7"
+    chart: "nodey545-1.0.8"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,9 +9,12 @@ repositories:
   url: http://chartmuseum-jx.34.105.246.143.nip.io/
 releases:
 - chart: dev/nodey545
-  version: 1.0.7
+  version: 1.0.8
   name: nodey545
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,8 +13,5 @@ releases:
   name: nodey545
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey545 to version 1.0.8 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge