### PR TITLE
chore: promote nodey545 to version 1.0.10 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey545/nodey545-1.0.10-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-1.0.10-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-14T09:43:01Z"
+  creationTimestamp: "2020-12-14T09:46:27Z"
   deletionTimestamp: null
-  name: 'nodey545-1.0.9'
+  name: 'nodey545-1.0.10'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.9
-      sha: 1729409b48d7480ff6a190deee0aad9554a5e4f8
+        chore: release 1.0.10
+      sha: 03e0f62b5d93ebc73b7d27e90332ead7dd91cdf9
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 5ab9e1e6b844900d18fd1160622026c27d7a238a
+      sha: 31428c3ddf5c9ddc4981d760c51d60df7729ae3f
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -39,11 +39,11 @@ spec:
         name: James Strachan
       message: |
         chore: regenerated
-      sha: 3291a2429fd6d123b34e4737caad17c2acdc7153
+      sha: fb235b3ff9e9eec149302cdb592bf0adeeae79b6
   gitHttpUrl: https://github.com/jstrachan/nodey545
   gitOwner: jstrachan
   gitRepository: nodey545
   name: 'nodey545'
-  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v1.0.9
-  version: v1.0.9
+  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v1.0.10
+  version: v1.0.10
 status: {}

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey545-nodey545
   labels:
     draft: draft-app
-    chart: "nodey545-1.0.9"
+    chart: "nodey545-1.0.10"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey545-nodey545
       containers:
         - name: nodey545
-          image: "gcr.io/jenkins-x-labs-bdd/nodey545:1.0.9"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey545:1.0.10"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.9
+              value: 1.0.10
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey545
   labels:
-    chart: "nodey545-1.0.9"
+    chart: "nodey545-1.0.10"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,8 +13,5 @@ releases:
   name: nodey545
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,9 +9,12 @@ repositories:
   url: http://chartmuseum-jx.34.105.246.143.nip.io/
 releases:
 - chart: dev/nodey545
-  version: 1.0.9
+  version: 1.0.10
   name: nodey545
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey545 to version 1.0.10 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge