### PR TITLE
chore: promote nodey545 to version 1.0.12 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey545/nodey545-1.0.12-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-1.0.12-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-14T10:08:31Z"
+  creationTimestamp: "2020-12-14T10:12:02Z"
   deletionTimestamp: null
-  name: 'nodey545-1.0.11'
+  name: 'nodey545-1.0.12'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.11
-      sha: 8179a21d6ab87118ff87fe79f4d2e3b6009df40c
+        chore: release 1.0.12
+      sha: eb3834cbd55d87ddbe1ffc0b471296a079663702
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: c61955009b8f4b3ed66610870ff48c94f88f9a35
+      sha: 5a762df94dfa885010209e9ce302954d39ee152f
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -39,11 +39,11 @@ spec:
         name: James Strachan
       message: |
         chore: regenerated
-      sha: 9644e1a34c02272e92ec0b2dcad805656a7200ee
+      sha: 4b3a5f6d8018c7e5b1db8bf009bb5fa13e8a9532
   gitHttpUrl: https://github.com/jstrachan/nodey545
   gitOwner: jstrachan
   gitRepository: nodey545
   name: 'nodey545'
-  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v1.0.11
-  version: v1.0.11
+  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v1.0.12
+  version: v1.0.12
 status: {}

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey545-nodey545
   labels:
     draft: draft-app
-    chart: "nodey545-1.0.11"
+    chart: "nodey545-1.0.12"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey545-nodey545
       containers:
         - name: nodey545
-          image: "gcr.io/jenkins-x-labs-bdd/nodey545:1.0.11"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey545:1.0.12"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.11
+              value: 1.0.12
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey545
   labels:
-    chart: "nodey545-1.0.11"
+    chart: "nodey545-1.0.12"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,9 +9,12 @@ repositories:
   url: http://chartmuseum-jx.34.105.246.143.nip.io/
 releases:
 - chart: dev/nodey545
-  version: 1.0.11
+  version: 1.0.12
   name: nodey545
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,8 +13,5 @@ releases:
   name: nodey545
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey545 to version 1.0.12 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge