### PR TITLE
chore: promote nodey545 to version 1.0.13 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey545/nodey545-1.0.13-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-1.0.13-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-14T10:12:02Z"
+  creationTimestamp: "2020-12-14T11:01:45Z"
   deletionTimestamp: null
-  name: 'nodey545-1.0.12'
+  name: 'nodey545-1.0.13'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.12
-      sha: eb3834cbd55d87ddbe1ffc0b471296a079663702
+        chore: release 1.0.13
+      sha: e1d6b38a5d54ffb21b8f79cd1a07920e0f26fba2
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 5a762df94dfa885010209e9ce302954d39ee152f
+      sha: 2203468c7eb58a63dfebc1ffa0865b45b61b2cf1
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -39,11 +39,21 @@ spec:
         name: James Strachan
       message: |
         chore: regenerated
-      sha: 4b3a5f6d8018c7e5b1db8bf009bb5fa13e8a9532
+      sha: f5f46adc23a912d59bf9d3ca7ef032118870ada4
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      message: |
+        chore: regenerated
+      sha: 3a5d2750f217f5fb0f62311b63d21d1e28966762
   gitHttpUrl: https://github.com/jstrachan/nodey545
   gitOwner: jstrachan
   gitRepository: nodey545
   name: 'nodey545'
-  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v1.0.12
-  version: v1.0.12
+  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v1.0.13
+  version: v1.0.13
 status: {}

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey545-nodey545
   labels:
     draft: draft-app
-    chart: "nodey545-1.0.12"
+    chart: "nodey545-1.0.13"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey545-nodey545
       containers:
         - name: nodey545
-          image: "gcr.io/jenkins-x-labs-bdd/nodey545:1.0.12"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey545:1.0.13"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.12
+              value: 1.0.13
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey545
   labels:
-    chart: "nodey545-1.0.12"
+    chart: "nodey545-1.0.13"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,8 +13,5 @@ releases:
   name: nodey545
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,9 +9,12 @@ repositories:
   url: http://chartmuseum-jx.34.105.246.143.nip.io/
 releases:
 - chart: dev/nodey545
-  version: 1.0.12
+  version: 1.0.13
   name: nodey545
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey545 to version 1.0.13 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge