### PR TITLE
chore: promote nodey534 to version 1.0.9 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey534/nodey534-1.0.9-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey534/nodey534-1.0.9-release.yaml
@@ -1,0 +1,18 @@
+# Source: nodey534/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-14T16:46:09Z"
+  deletionTimestamp: null
+  name: 'nodey534-1.0.9'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  gitCloneUrl: https://github.com/jstrachan/nodey534.git
+  gitHttpUrl: https://github.com/jstrachan/nodey534
+  gitOwner: jstrachan
+  gitRepository: nodey534
+  name: 'nodey534'
+  version: v1.0.9
+status: {}

--- a/config-root/namespaces/jx-staging/nodey534/nodey534-ingress.yaml
+++ b/config-root/namespaces/jx-staging/nodey534/nodey534-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: nodey534/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: nodey534
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey534
+              servicePort: 80
+      host: nodey534-jx-staging.34.105.246.143.nip.io

--- a/config-root/namespaces/jx-staging/nodey534/nodey534-nodey534-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey534/nodey534-nodey534-deploy.yaml
@@ -1,0 +1,55 @@
+# Source: nodey534/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodey534-nodey534
+  labels:
+    draft: draft-app
+    chart: "nodey534-1.0.9"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nodey534-nodey534
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: nodey534-nodey534
+    spec:
+      containers:
+        - name: nodey534
+          image: "gcr.io/jenkins-x-labs-bdd/nodey534:1.0.9"
+          imagePullPolicy: IfNotPresent
+          env:
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/nodey534/nodey534-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey534/nodey534-svc.yaml
@@ -1,0 +1,21 @@
+# Source: nodey534/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey534
+  labels:
+    chart: "nodey534-1.0.9"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey534-nodey534

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,13 +13,10 @@ releases:
   name: nodey545
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/nodey534
   version: 1.0.9
   name: nodey534
-  forceNamespace: ""
-  skipDeps: null
+  values:
+  - jx-values.yaml
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,5 +13,13 @@ releases:
   name: nodey545
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
+- chart: dev/nodey534
+  version: 1.0.9
+  name: nodey534
+  forceNamespace: ""
+  skipDeps: null
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey534 to version 1.0.9 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge