### PR TITLE
chore: promote nodey553 to version 1.0.1 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey553/nodey553-1.0.1-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey553/nodey553-1.0.1-release.yaml
@@ -1,0 +1,49 @@
+# Source: nodey553/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-18T16:46:43Z"
+  deletionTimestamp: null
+  name: 'nodey553-1.0.1'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 1.0.1
+      sha: 3ba1fe8c119d8a9273f7c9b7cc98b28a1ff3409c
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 34ccbe756212bd72f4341c3dddb29ae99d3da31e
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      message: |
+        chore: Jenkins X build pack
+      sha: 68cb0c18c912a5b1e3a87e42a1bf07f7b21144b2
+  gitHttpUrl: https://github.com/jstrachan/nodey553
+  gitOwner: jstrachan
+  gitRepository: nodey553
+  name: 'nodey553'
+  releaseNotesURL: https://github.com/jstrachan/nodey553/releases/tag/v1.0.1
+  version: v1.0.1
+status: {}

--- a/config-root/namespaces/jx-staging/nodey553/nodey553-ingress.yaml
+++ b/config-root/namespaces/jx-staging/nodey553/nodey553-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: nodey553/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: nodey553
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey553
+              servicePort: 80
+      host: nodey553-jx-staging.34.105.246.143.nip.io

--- a/config-root/namespaces/jx-staging/nodey553/nodey553-nodey553-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey553/nodey553-nodey553-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: nodey553/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodey553-nodey553
+  labels:
+    draft: draft-app
+    chart: "nodey553-1.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nodey553-nodey553
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: nodey553-nodey553
+    spec:
+      serviceAccountName: nodey553-nodey553
+      containers:
+        - name: nodey553
+          image: "gcr.io/jenkins-x-labs-bdd/nodey553:1.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 1.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/nodey553/nodey553-nodey553-sa.yaml
+++ b/config-root/namespaces/jx-staging/nodey553/nodey553-nodey553-sa.yaml
@@ -1,0 +1,8 @@
+# Source: nodey553/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nodey553-nodey553
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/nodey553/nodey553-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey553/nodey553-svc.yaml
@@ -1,0 +1,21 @@
+# Source: nodey553/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey553
+  labels:
+    chart: "nodey553-1.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey553-nodey553

--- a/config-root/namespaces/myjenkins8/jenkins/templates/tests/jenkins-ui-test-zji9y-pod.yaml
+++ b/config-root/namespaces/myjenkins8/jenkins/templates/tests/jenkins-ui-test-zji9y-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-jf0bt"
+  name: "jenkins-ui-test-zji9y"
   namespace: myjenkins8
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,15 +13,27 @@ releases:
   name: nodey545
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 - chart: dev/nodey534
   version: 1.0.9
   name: nodey534
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 - chart: dev/nodey546
   version: 1.0.2
   name: nodey546
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
+- chart: dev/nodey553
+  version: 1.0.1
+  name: nodey553
+  forceNamespace: ""
+  skipDeps: null
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,27 +13,20 @@ releases:
   name: nodey545
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/nodey534
   version: 1.0.9
   name: nodey534
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/nodey546
   version: 1.0.2
   name: nodey546
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/nodey553
   version: 1.0.1
   name: nodey553
-  forceNamespace: ""
-  skipDeps: null
+  values:
+  - jx-values.yaml
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey553 to version 1.0.1 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge