### PR TITLE
chore: promote nodey553 to version 1.0.2 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey553/nodey553-1.0.2-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey553/nodey553-1.0.2-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-18T16:46:43Z"
+  creationTimestamp: "2020-12-18T16:52:49Z"
   deletionTimestamp: null
-  name: 'nodey553-1.0.1'
+  name: 'nodey553-1.0.2'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.1
-      sha: 3ba1fe8c119d8a9273f7c9b7cc98b28a1ff3409c
+        chore: release 1.0.2
+      sha: 3d5a92b23c86ece51b02383f38daaadcae07b1a4
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,21 +29,20 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 34ccbe756212bd72f4341c3dddb29ae99d3da31e
+      sha: 7f28a9bc1839a6989ecba50236d9324ed99cd03e
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
       branch: master
       committer:
-        email: james.strachan@gmail.com
-        name: James Strachan
-      message: |
-        chore: Jenkins X build pack
-      sha: 68cb0c18c912a5b1e3a87e42a1bf07f7b21144b2
+        email: noreply@github.com
+        name: GitHub
+      message: 'chore: try pr'
+      sha: 36250bf792f479b4e115d1d12a788465f0584db6
   gitHttpUrl: https://github.com/jstrachan/nodey553
   gitOwner: jstrachan
   gitRepository: nodey553
   name: 'nodey553'
-  releaseNotesURL: https://github.com/jstrachan/nodey553/releases/tag/v1.0.1
-  version: v1.0.1
+  releaseNotesURL: https://github.com/jstrachan/nodey553/releases/tag/v1.0.2
+  version: v1.0.2
 status: {}

--- a/config-root/namespaces/jx-staging/nodey553/nodey553-nodey553-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey553/nodey553-nodey553-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey553-nodey553
   labels:
     draft: draft-app
-    chart: "nodey553-1.0.1"
+    chart: "nodey553-1.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey553-nodey553
       containers:
         - name: nodey553
-          image: "gcr.io/jenkins-x-labs-bdd/nodey553:1.0.1"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey553:1.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.1
+              value: 1.0.2
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey553/nodey553-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey553/nodey553-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey553
   labels:
-    chart: "nodey553-1.0.1"
+    chart: "nodey553-1.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkins8/jenkins/templates/tests/jenkins-ui-test-h18xl-pod.yaml
+++ b/config-root/namespaces/myjenkins8/jenkins/templates/tests/jenkins-ui-test-h18xl-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-zji9y"
+  name: "jenkins-ui-test-h18xl"
   namespace: myjenkins8
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,20 +13,29 @@ releases:
   name: nodey545
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 - chart: dev/nodey534
   version: 1.0.9
   name: nodey534
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 - chart: dev/nodey546
   version: 1.0.2
   name: nodey546
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 - chart: dev/nodey553
-  version: 1.0.1
+  version: 1.0.2
   name: nodey553
   values:
   - jx-values.yaml
+  forceNamespace: ""
+  skipDeps: null
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,29 +13,20 @@ releases:
   name: nodey545
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/nodey534
   version: 1.0.9
   name: nodey534
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/nodey546
   version: 1.0.2
   name: nodey546
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/nodey553
   version: 1.0.2
   name: nodey553
   values:
   - jx-values.yaml
-  forceNamespace: ""
-  skipDeps: null
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey553 to version 1.0.2 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge