### PR TITLE
chore: promote nodey554 to version 1.0.2 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey554/nodey554-1.0.2-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-1.0.2-release.yaml
@@ -1,0 +1,48 @@
+# Source: nodey554/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-19T10:11:20Z"
+  deletionTimestamp: null
+  name: 'nodey554-1.0.2'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 1.0.2
+      sha: 10e7adf51cd90bd26c948edf15ee48b146af5b50
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 29a0a00b829091097b7c7cb0c7b3096f48a2f94c
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: noreply@github.com
+        name: GitHub
+      message: Update release.yaml
+      sha: 58a7e38ab14677b2dcf76eee84b491cf000ae0b1
+  gitHttpUrl: https://github.com/jstrachan/nodey554
+  gitOwner: jstrachan
+  gitRepository: nodey554
+  name: 'nodey554'
+  releaseNotesURL: https://github.com/jstrachan/nodey554/releases/tag/v1.0.2
+  version: v1.0.2
+status: {}

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-ingress.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: nodey554/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: nodey554
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey554
+              servicePort: 80
+      host: nodey554-jx-staging.34.105.246.143.nip.io

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-nodey554-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-nodey554-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: nodey554/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodey554-nodey554
+  labels:
+    draft: draft-app
+    chart: "nodey554-1.0.2"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nodey554-nodey554
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: nodey554-nodey554
+    spec:
+      serviceAccountName: nodey554-nodey554
+      containers:
+        - name: nodey554
+          image: "gcr.io/jenkins-x-labs-bdd/nodey554:1.0.2"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 1.0.2
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-nodey554-sa.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-nodey554-sa.yaml
@@ -1,0 +1,8 @@
+# Source: nodey554/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nodey554-nodey554
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-svc.yaml
@@ -1,0 +1,21 @@
+# Source: nodey554/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey554
+  labels:
+    chart: "nodey554-1.0.2"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey554-nodey554

--- a/config-root/namespaces/jx/jx-build-controller/jenkins-x-controllerbuild-sa.yaml
+++ b/config-root/namespaces/jx/jx-build-controller/jenkins-x-controllerbuild-sa.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jenkins-x-controllerbuild
   labels:
     app: jx-build-controller
-    chart: jx-build-controller-0.0.17
+    chart: jx-build-controller-0.0.18
     release: jx-build-controller
     heritage: Helm
     gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx/jx-build-controller/jx-build-controller-deploy.yaml
+++ b/config-root/namespaces/jx/jx-build-controller/jx-build-controller-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx-build-controller
   labels:
     app: jx-build-controller
-    chart: jx-build-controller-0.0.17
+    chart: jx-build-controller-0.0.18
     release: jx-build-controller
     heritage: Helm
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -29,7 +29,7 @@ spec:
         - name: jx-build-controller
           command: [jx-build-controller]
           imagePullPolicy:
-          image: "gcr.io/jenkinsxio/jx-build-controller:0.0.17"
+          image: "gcr.io/jenkinsxio/jx-build-controller:0.0.18"
           ports:
             - name: http
               containerPort: 8080

--- a/config-root/namespaces/myjenkins8/jenkins/templates/tests/jenkins-ui-test-a8br8-pod.yaml
+++ b/config-root/namespaces/myjenkins8/jenkins/templates/tests/jenkins-ui-test-a8br8-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-pwd6h"
+  name: "jenkins-ui-test-a8br8"
   namespace: myjenkins8
   annotations:
     "helm.sh/hook": test-success

--- a/config-root/namespaces/myjenkins8/jenkins/templates/tests/jenkins-ui-test-k32s0-pod.yaml
+++ b/config-root/namespaces/myjenkins8/jenkins/templates/tests/jenkins-ui-test-k32s0-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-a8br8"
+  name: "jenkins-ui-test-k32s0"
   namespace: myjenkins8
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -4,5 +4,14 @@ environments:
     values:
     - jx-values.yaml
 namespace: jx-staging
+repositories:
+- name: dev
+  url: http://chartmuseum-jx.34.105.246.143.nip.io/
+releases:
+- chart: dev/nodey554
+  version: 1.0.2
+  name: nodey554
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx/helmfile.yaml
+++ b/helmfiles/jx/helmfile.yaml
@@ -72,7 +72,7 @@ releases:
   - ../../versionStream/charts/stable/chartmuseum/values.yaml.gotmpl
   - jx-values.yaml
 - chart: jx3/jx-build-controller
-  version: 0.0.17
+  version: 0.0.18
   name: jx-build-controller
   values:
   - ../../versionStream/charts/jx3/jx-build-controller/values.yaml.gotmpl


### PR DESCRIPTION
chore: promote nodey554 to version 1.0.2 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge