### PR TITLE
chore: promote nodey554 to version 1.0.3 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey554/nodey554-1.0.3-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-1.0.3-release.yaml
@@ -1,0 +1,48 @@
+# Source: nodey554/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-19T10:16:29Z"
+  deletionTimestamp: null
+  name: 'nodey554-1.0.3'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 1.0.3
+      sha: dd3647d965b69b96923abe3c94d90c92323f6a70
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 18d4b23d698498e1ddce4e84a1e6f220b8bd68d8
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: noreply@github.com
+        name: GitHub
+      message: Update release.yaml
+      sha: bcdc1d18ce41576c721ea97241f0b3287a234a78
+  gitHttpUrl: https://github.com/jstrachan/nodey554
+  gitOwner: jstrachan
+  gitRepository: nodey554
+  name: 'nodey554'
+  releaseNotesURL: https://github.com/jstrachan/nodey554/releases/tag/v1.0.3
+  version: v1.0.3
+status: {}

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-ingress.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: nodey554/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: nodey554
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey554
+              servicePort: 80
+      host: nodey554-jx-staging.34.105.246.143.nip.io

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-nodey554-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-nodey554-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: nodey554/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodey554-nodey554
+  labels:
+    draft: draft-app
+    chart: "nodey554-1.0.3"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nodey554-nodey554
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: nodey554-nodey554
+    spec:
+      serviceAccountName: nodey554-nodey554
+      containers:
+        - name: nodey554
+          image: "gcr.io/jenkins-x-labs-bdd/nodey554:1.0.3"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 1.0.3
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-nodey554-sa.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-nodey554-sa.yaml
@@ -1,0 +1,8 @@
+# Source: nodey554/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nodey554-nodey554
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-svc.yaml
@@ -1,0 +1,21 @@
+# Source: nodey554/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey554
+  labels:
+    chart: "nodey554-1.0.3"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey554-nodey554

--- a/config-root/namespaces/jx/jx-build-controller/jenkins-x-controllerbuild-sa.yaml
+++ b/config-root/namespaces/jx/jx-build-controller/jenkins-x-controllerbuild-sa.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jenkins-x-controllerbuild
   labels:
     app: jx-build-controller
-    chart: jx-build-controller-0.0.17
+    chart: jx-build-controller-0.0.18
     release: jx-build-controller
     heritage: Helm
     gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx/jx-build-controller/jx-build-controller-deploy.yaml
+++ b/config-root/namespaces/jx/jx-build-controller/jx-build-controller-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx-build-controller
   labels:
     app: jx-build-controller
-    chart: jx-build-controller-0.0.17
+    chart: jx-build-controller-0.0.18
     release: jx-build-controller
     heritage: Helm
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -29,7 +29,7 @@ spec:
         - name: jx-build-controller
           command: [jx-build-controller]
           imagePullPolicy:
-          image: "gcr.io/jenkinsxio/jx-build-controller:0.0.17"
+          image: "gcr.io/jenkinsxio/jx-build-controller:0.0.18"
           ports:
             - name: http
               containerPort: 8080

--- a/config-root/namespaces/myjenkins8/jenkins/templates/tests/jenkins-ui-test-m76sy-pod.yaml
+++ b/config-root/namespaces/myjenkins8/jenkins/templates/tests/jenkins-ui-test-m76sy-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-pwd6h"
+  name: "jenkins-ui-test-m76sy"
   namespace: myjenkins8
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -11,5 +11,7 @@ releases:
 - chart: dev/nodey554
   version: 1.0.3
   name: nodey554
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -4,5 +4,12 @@ environments:
     values:
     - jx-values.yaml
 namespace: jx-staging
+repositories:
+- name: dev
+  url: http://chartmuseum-jx.34.105.246.143.nip.io/
+releases:
+- chart: dev/nodey554
+  version: 1.0.3
+  name: nodey554
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey554 to version 1.0.3 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge