### PR TITLE
chore: promote nodey554 to version 1.0.6 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey554/nodey554-1.0.6-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-1.0.6-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-20T08:29:18Z"
+  creationTimestamp: "2020-12-20T08:36:34Z"
   deletionTimestamp: null
-  name: 'nodey554-1.0.5'
+  name: 'nodey554-1.0.6'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.5
-      sha: 3f64ac0a4fd1beb90d2452b046a3bfee2537f400
+        chore: release 1.0.6
+      sha: dac82bfd94a023ab164af83d97f7d9edd8fa6860
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 0c08f9734fa6678eedd3ee604a6a53d6ba1c6f60
+      sha: d0b4f42b60d93ced98303e2e337be2e022a7a075
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -37,12 +37,12 @@ spec:
       committer:
         email: noreply@github.com
         name: GitHub
-      message: Update release.yaml
-      sha: f92699bac8cea0d1892a1d047e8d35b9aab8c1bd
+      message: 'fix: avoid env'
+      sha: 94d49fe72b317d8d1b9826372ed904954e206b19
   gitHttpUrl: https://github.com/jstrachan/nodey554
   gitOwner: jstrachan
   gitRepository: nodey554
   name: 'nodey554'
-  releaseNotesURL: https://github.com/jstrachan/nodey554/releases/tag/v1.0.5
-  version: v1.0.5
+  releaseNotesURL: https://github.com/jstrachan/nodey554/releases/tag/v1.0.6
+  version: v1.0.6
 status: {}

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-nodey554-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-nodey554-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey554-nodey554
   labels:
     draft: draft-app
-    chart: "nodey554-1.0.5"
+    chart: "nodey554-1.0.6"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey554-nodey554
       containers:
         - name: nodey554
-          image: "gcr.io/jenkins-x-labs-bdd/nodey554:1.0.5"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey554:1.0.6"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.5
+              value: 1.0.6
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey554
   labels:
-    chart: "nodey554-1.0.5"
+    chart: "nodey554-1.0.6"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkins8/jenkins/templates/tests/jenkins-ui-test-8mdwb-pod.yaml
+++ b/config-root/namespaces/myjenkins8/jenkins/templates/tests/jenkins-ui-test-8mdwb-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-aort0"
+  name: "jenkins-ui-test-8mdwb"
   namespace: myjenkins8
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://chartmuseum-jx.34.105.246.143.nip.io/
 releases:
 - chart: dev/nodey554
-  version: 1.0.5
+  version: 1.0.6
   name: nodey554
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey554 to version 1.0.6 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge