### PR TITLE
chore: promote nodey554 to version 1.0.10 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey554/nodey554-1.0.10-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-1.0.10-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-20T08:51:04Z"
+  creationTimestamp: "2020-12-21T07:28:45Z"
   deletionTimestamp: null
-  name: 'nodey554-1.0.9'
+  name: 'nodey554-1.0.10'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.9
-      sha: 3ee16557222e711365720d274a24a1a8e465d9ca
+        chore: release 1.0.10
+      sha: 89926f8a77db1c8d57d0048a7b6823ef535ee815
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: a930619d606dbdb7854d90d3d067751005027ae1
+      sha: b414ac80943ee43b42583dd9685fd42eaced92b2
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -38,11 +38,11 @@ spec:
         email: noreply@github.com
         name: GitHub
       message: Update index.html
-      sha: 2d02db7d3a71a01df938b0c3d26dd345b133956c
+      sha: ca161c26b943bd148990eb2f95e8ac81e2996a67
   gitHttpUrl: https://github.com/jstrachan/nodey554
   gitOwner: jstrachan
   gitRepository: nodey554
   name: 'nodey554'
-  releaseNotesURL: https://github.com/jstrachan/nodey554/releases/tag/v1.0.9
-  version: v1.0.9
+  releaseNotesURL: https://github.com/jstrachan/nodey554/releases/tag/v1.0.10
+  version: v1.0.10
 status: {}

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-nodey554-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-nodey554-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey554-nodey554
   labels:
     draft: draft-app
-    chart: "nodey554-1.0.9"
+    chart: "nodey554-1.0.10"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey554-nodey554
       containers:
         - name: nodey554
-          image: "gcr.io/jenkins-x-labs-bdd/nodey554:1.0.9"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey554:1.0.10"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.9
+              value: 1.0.10
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey554
   labels:
-    chart: "nodey554-1.0.9"
+    chart: "nodey554-1.0.10"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkins8/jenkins/templates/tests/jenkins-ui-test-hx9mp-pod.yaml
+++ b/config-root/namespaces/myjenkins8/jenkins/templates/tests/jenkins-ui-test-hx9mp-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-8voxf"
+  name: "jenkins-ui-test-hx9mp"
   namespace: myjenkins8
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://chartmuseum-jx.34.105.246.143.nip.io/
 releases:
 - chart: dev/nodey554
-  version: 1.0.9
+  version: 1.0.10
   name: nodey554
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey554 to version 1.0.10 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge