### PR TITLE
chore: promote nodey554 to version 1.0.14 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey554/nodey554-1.0.14-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-1.0.14-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-21T13:41:51Z"
+  creationTimestamp: "2020-12-21T14:46:07Z"
   deletionTimestamp: null
-  name: 'nodey554-1.0.13'
+  name: 'nodey554-1.0.14'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.13
-      sha: 4fc69727d212b8a7e22c3c1a76ab1cde3b6f1d1c
+        chore: release 1.0.14
+      sha: efb423df19002bed4eba20cc2ef63849a1357dc1
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 97fd879d659e2847a658f0d456e9abb053b9dbda
+      sha: 1cf85bb99c5454637a32354d156e2c5be598ff55
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -38,11 +38,20 @@ spec:
         email: noreply@github.com
         name: GitHub
       message: Update index.html
-      sha: 3f8146482dcb76bb798de1b6fd3e5f6a41d7b2fd
+      sha: 2187121e32e490e7f05a4d66671f8aa858f84041
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: noreply@github.com
+        name: GitHub
+      message: Update index.html
+      sha: 4a87f924c21409143f6e88178abcca553a1549b8
   gitHttpUrl: https://github.com/jstrachan/nodey554
   gitOwner: jstrachan
   gitRepository: nodey554
   name: 'nodey554'
-  releaseNotesURL: https://github.com/jstrachan/nodey554/releases/tag/v1.0.13
-  version: v1.0.13
+  releaseNotesURL: https://github.com/jstrachan/nodey554/releases/tag/v1.0.14
+  version: v1.0.14
 status: {}

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-ksvc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey554
   labels:
-    chart: "nodey554-1.0.13"
+    chart: "nodey554-1.0.14"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
 spec:
@@ -14,11 +14,11 @@ spec:
         autoscaling.knative.dev/minScale: "0"
     spec:
       containers:
-        - image: "gcr.io/jenkins-x-labs-bdd/nodey554:1.0.13"
+        - image: "gcr.io/jenkins-x-labs-bdd/nodey554:1.0.14"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.13
+              value: 1.0.14
           livenessProbe:
             httpGet:
               path: /

--- a/config-root/namespaces/myjenkins8/jenkins/templates/tests/jenkins-ui-test-r3cbm-pod.yaml
+++ b/config-root/namespaces/myjenkins8/jenkins/templates/tests/jenkins-ui-test-r3cbm-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-s7mqd"
+  name: "jenkins-ui-test-r3cbm"
   namespace: myjenkins8
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://chartmuseum-jx.34.105.246.143.xip.io/
 releases:
 - chart: dev/nodey554
-  version: 1.0.13
+  version: 1.0.14
   name: nodey554
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey554 to version 1.0.14 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge