### PR TITLE
chore: promote nodey554 to version 1.0.19 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey554/nodey554-1.0.19-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-1.0.19-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-04T08:47:58Z"
+  creationTimestamp: "2021-01-04T15:36:26Z"
   deletionTimestamp: null
-  name: 'nodey554-1.0.18'
+  name: 'nodey554-1.0.19'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.18
-      sha: a95076c82ad089eacbb6cc82955b1730bd207afd
+        chore: release 1.0.19
+      sha: 7fb269098bbe779e81230394688e951f67be803e
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: d25e894c826fea190928b12449c3cf9e5ef99987
+      sha: 2e2b7fe47f7f110b3fa4bf32858b8dffb26a0b6b
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -38,11 +38,11 @@ spec:
         email: noreply@github.com
         name: GitHub
       message: Update index.html
-      sha: efd3c8542a0d393bf1cebda3085cda57c8299d25
+      sha: 04384bdced874a44b3065853ecdcfd801394ee45
   gitHttpUrl: https://github.com/jstrachan/nodey554
   gitOwner: jstrachan
   gitRepository: nodey554
   name: 'nodey554'
-  releaseNotesURL: https://github.com/jstrachan/nodey554/releases/tag/v1.0.18
-  version: v1.0.18
+  releaseNotesURL: https://github.com/jstrachan/nodey554/releases/tag/v1.0.19
+  version: v1.0.19
 status: {}

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-ksvc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey554
   labels:
-    chart: "nodey554-1.0.18"
+    chart: "nodey554-1.0.19"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
 spec:
@@ -14,11 +14,11 @@ spec:
         autoscaling.knative.dev/minScale: "0"
     spec:
       containers:
-        - image: "gcr.io/jenkins-x-labs-bdd/nodey554:1.0.18"
+        - image: "gcr.io/jenkins-x-labs-bdd/nodey554:1.0.19"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.18
+              value: 1.0.19
           livenessProbe:
             httpGet:
               path: /

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-qt9yy-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-qt9yy-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-sx9ua"
+  name: "jenkins-ui-test-qt9yy"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://chartmuseum-jx.34.105.246.143.xip.io/
 releases:
 - chart: dev/nodey554
-  version: 1.0.18
+  version: 1.0.19
   name: nodey554
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey554 to version 1.0.19 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge