### PR TITLE
chore: promote nodey545 to version 3.0.8

### DIFF
--- a/config-root/namespaces/jx-staging/nodey545/nodey545-3.0.8-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-3.0.8-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-12T09:00:00Z"
+  creationTimestamp: "2021-01-12T09:55:06Z"
   deletionTimestamp: null
-  name: 'nodey545-3.0.6'
+  name: 'nodey545-3.0.8'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 3.0.6
-      sha: 7d0dd75f2c439bf2ea8ae5f82ea1c40281542087
+        chore: release 3.0.8
+      sha: ab14f6641968fa4001e6c03b7c4b089aa7fedd95
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 5147a489c67c8fcec786b5fb124fd3084f618f37
+      sha: 36783168ab5b745dc24191aeba4877f802ed228d
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -38,12 +38,12 @@ spec:
         email: james.strachan@gmail.com
         name: James Strachan
       message: |
-        chore: avoid full path
-      sha: 1ae26df3d4d16fe59df14152631f398ef68dd914
+        fix: add helm token
+      sha: 5ee3cec025f7d2b797e1157301b6472a87b97ea4
   gitHttpUrl: https://github.com/jstrachan/nodey545
   gitOwner: jstrachan
   gitRepository: nodey545
   name: 'nodey545'
-  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.6
-  version: v3.0.6
+  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.8
+  version: v3.0.8
 status: {}

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey545-nodey545
   labels:
     draft: draft-app
-    chart: "nodey545-3.0.6"
+    chart: "nodey545-3.0.8"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey545-nodey545
       containers:
         - name: nodey545
-          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.6"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.8"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 3.0.6
+              value: 3.0.8
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey545
   labels:
-    chart: "nodey545-3.0.6"
+    chart: "nodey545-3.0.8"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-6usib-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-6usib-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-z9xil"
+  name: "jenkins-ui-test-6usib"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey545
-  version: 3.0.6
+  version: 3.0.8
   name: nodey545
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey545 to version 3.0.8

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge