### PR TITLE
chore: promote nodey545 to version 3.0.10

### DIFF
--- a/config-root/namespaces/jx-staging/nodey545/nodey545-3.0.10-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-3.0.10-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-12T09:55:06Z"
+  creationTimestamp: "2021-01-12T10:01:53Z"
   deletionTimestamp: null
-  name: 'nodey545-3.0.8'
+  name: 'nodey545-3.0.10'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 3.0.8
-      sha: ab14f6641968fa4001e6c03b7c4b089aa7fedd95
+        chore: release 3.0.10
+      sha: 970f4e9176735e59795239abdc36ee741af70eb4
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 36783168ab5b745dc24191aeba4877f802ed228d
+      sha: 6dffd32a6237f9e0ec4d92b42a348ac54248dcb5
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -38,12 +38,12 @@ spec:
         email: james.strachan@gmail.com
         name: James Strachan
       message: |
-        fix: add helm token
-      sha: 5ee3cec025f7d2b797e1157301b6472a87b97ea4
+        fix: add env vars
+      sha: 9183e939e435e559ef5ad9e65a9938fac59081c1
   gitHttpUrl: https://github.com/jstrachan/nodey545
   gitOwner: jstrachan
   gitRepository: nodey545
   name: 'nodey545'
-  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.8
-  version: v3.0.8
+  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.10
+  version: v3.0.10
 status: {}

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey545-nodey545
   labels:
     draft: draft-app
-    chart: "nodey545-3.0.8"
+    chart: "nodey545-3.0.10"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey545-nodey545
       containers:
         - name: nodey545
-          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.8"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.10"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 3.0.8
+              value: 3.0.10
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey545
   labels:
-    chart: "nodey545-3.0.8"
+    chart: "nodey545-3.0.10"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-qggg0-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-qggg0-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-6usib"
+  name: "jenkins-ui-test-qggg0"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey545
-  version: 3.0.8
+  version: 3.0.10
   name: nodey545
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey545 to version 3.0.10

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge