### PR TITLE
chore: promote nodey545 to version 3.0.14

### DIFF
--- a/config-root/namespaces/jx-staging/nodey545/nodey545-3.0.14-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-3.0.14-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-12T10:06:23Z"
+  creationTimestamp: "2021-01-12T10:10:33Z"
   deletionTimestamp: null
-  name: 'nodey545-3.0.12'
+  name: 'nodey545-3.0.14'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 3.0.12
-      sha: 432c592e0af125251f1c6a2e6d4e066d5e5ee003
+        chore: release 3.0.14
+      sha: f221df661e2ead7dcb0f6c3c4adab41be1d02789
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: f013cab03bc2efd70261b70e7dbd8ba7bc9e0f55
+      sha: f95d690ffb2191ac1b02691a44001edb008bf89d
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -38,12 +38,12 @@ spec:
         email: james.strachan@gmail.com
         name: James Strachan
       message: |
-        fix: add env vars
-      sha: 8df1db75de6b248d714f1ca377ea9a35fdd4f9d0
+        fix: add user
+      sha: b6108f1cb6722d9e1924828695a9300bf8f9649c
   gitHttpUrl: https://github.com/jstrachan/nodey545
   gitOwner: jstrachan
   gitRepository: nodey545
   name: 'nodey545'
-  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.12
-  version: v3.0.12
+  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.14
+  version: v3.0.14
 status: {}

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey545-nodey545
   labels:
     draft: draft-app
-    chart: "nodey545-3.0.12"
+    chart: "nodey545-3.0.14"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey545-nodey545
       containers:
         - name: nodey545
-          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.12"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.14"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 3.0.12
+              value: 3.0.14
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey545
   labels:
-    chart: "nodey545-3.0.12"
+    chart: "nodey545-3.0.14"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-3ohpr-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-3ohpr-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-z6ymu"
+  name: "jenkins-ui-test-3ohpr"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey545
-  version: 3.0.12
+  version: 3.0.14
   name: nodey545
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey545 to version 3.0.14

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge