### PR TITLE
chore: promote nodey545 to version 3.0.14

### DIFF
--- a/config-root/namespaces/jx-production/nodey545/nodey545-3.0.14-release.yaml
+++ b/config-root/namespaces/jx-production/nodey545/nodey545-3.0.14-release.yaml
@@ -1,0 +1,49 @@
+# Source: nodey545/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-01-12T10:10:33Z"
+  deletionTimestamp: null
+  name: 'nodey545-3.0.14'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 3.0.14
+      sha: f221df661e2ead7dcb0f6c3c4adab41be1d02789
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: f95d690ffb2191ac1b02691a44001edb008bf89d
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      message: |
+        fix: add user
+      sha: b6108f1cb6722d9e1924828695a9300bf8f9649c
+  gitHttpUrl: https://github.com/jstrachan/nodey545
+  gitOwner: jstrachan
+  gitRepository: nodey545
+  name: 'nodey545'
+  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.14
+  version: v3.0.14
+status: {}

--- a/config-root/namespaces/jx-production/nodey545/nodey545-ingress.yaml
+++ b/config-root/namespaces/jx-production/nodey545/nodey545-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: nodey545/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: nodey545
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey545
+              servicePort: 80
+      host: nodey545-jx-production.34.105.246.143.xip.io

--- a/config-root/namespaces/jx-production/nodey545/nodey545-nodey545-deploy.yaml
+++ b/config-root/namespaces/jx-production/nodey545/nodey545-nodey545-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: nodey545/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodey545-nodey545
+  labels:
+    draft: draft-app
+    chart: "nodey545-3.0.14"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nodey545-nodey545
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: nodey545-nodey545
+    spec:
+      serviceAccountName: nodey545-nodey545
+      containers:
+        - name: nodey545
+          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.14"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 3.0.14
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/nodey545/nodey545-nodey545-sa.yaml
+++ b/config-root/namespaces/jx-production/nodey545/nodey545-nodey545-sa.yaml
@@ -1,0 +1,8 @@
+# Source: nodey545/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nodey545-nodey545
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/nodey545/nodey545-svc.yaml
+++ b/config-root/namespaces/jx-production/nodey545/nodey545-svc.yaml
@@ -1,0 +1,21 @@
+# Source: nodey545/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey545
+  labels:
+    chart: "nodey545-3.0.14"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey545-nodey545

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-5akjg-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-5akjg-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-z6ymu"
+  name: "jenkins-ui-test-5akjg"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -4,5 +4,12 @@ environments:
     values:
     - jx-values.yaml
 namespace: jx-production
+repositories:
+- name: dev
+  url: http://chartmuseum-jx.34.105.246.143.xip.io/
+releases:
+- chart: dev/nodey545
+  version: 3.0.14
+  name: nodey545
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -11,5 +11,7 @@ releases:
 - chart: dev/nodey545
   version: 3.0.14
   name: nodey545
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey545 to version 3.0.14

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge