### PR TITLE
chore: promote nodey545 to version 3.0.16

### DIFF
--- a/config-root/namespaces/jx-staging/nodey545/nodey545-3.0.16-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-3.0.16-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-12T10:10:33Z"
+  creationTimestamp: "2021-01-12T10:55:43Z"
   deletionTimestamp: null
-  name: 'nodey545-3.0.14'
+  name: 'nodey545-3.0.16'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 3.0.14
-      sha: f221df661e2ead7dcb0f6c3c4adab41be1d02789
+        chore: release 3.0.16
+      sha: 3db2aa3d8a2a4533b262c7226eb7d5a1be6135bd
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: f95d690ffb2191ac1b02691a44001edb008bf89d
+      sha: f2a4dc05c4819a48fdb0ddba61148249cd738d3b
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -39,11 +39,11 @@ spec:
         name: James Strachan
       message: |
         fix: add user
-      sha: b6108f1cb6722d9e1924828695a9300bf8f9649c
+      sha: 54c7752827d555cfb25b8f12c06cb01712f4ecfb
   gitHttpUrl: https://github.com/jstrachan/nodey545
   gitOwner: jstrachan
   gitRepository: nodey545
   name: 'nodey545'
-  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.14
-  version: v3.0.14
+  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.16
+  version: v3.0.16
 status: {}

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey545-nodey545
   labels:
     draft: draft-app
-    chart: "nodey545-3.0.14"
+    chart: "nodey545-3.0.16"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey545-nodey545
       containers:
         - name: nodey545
-          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.14"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.16"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 3.0.14
+              value: 3.0.16
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey545
   labels:
-    chart: "nodey545-3.0.14"
+    chart: "nodey545-3.0.16"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-ir6ro-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-ir6ro-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-3ohpr"
+  name: "jenkins-ui-test-ir6ro"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey545
-  version: 3.0.14
+  version: 3.0.16
   name: nodey545
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey545 to version 3.0.16

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge