### PR TITLE
chore: promote nodey545 to version 3.0.19

### DIFF
--- a/config-root/namespaces/jx-staging/nodey545/nodey545-3.0.19-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-3.0.19-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-12T10:55:43Z"
+  creationTimestamp: "2021-01-12T11:22:25Z"
   deletionTimestamp: null
-  name: 'nodey545-3.0.16'
+  name: 'nodey545-3.0.19'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 3.0.16
-      sha: 3db2aa3d8a2a4533b262c7226eb7d5a1be6135bd
+        chore: release 3.0.19
+      sha: 62022188ba36ffe8fca32486e485b59a3791cefb
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: f2a4dc05c4819a48fdb0ddba61148249cd738d3b
+      sha: 201a5ce974dcacfcadfbde0f8ade2358ee305fcd
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -38,12 +38,12 @@ spec:
         email: james.strachan@gmail.com
         name: James Strachan
       message: |
-        fix: add user
-      sha: 54c7752827d555cfb25b8f12c06cb01712f4ecfb
+        fix: avoid env
+      sha: eae60a2c47ee7e0a1b89e818355f3688c5237dbe
   gitHttpUrl: https://github.com/jstrachan/nodey545
   gitOwner: jstrachan
   gitRepository: nodey545
   name: 'nodey545'
-  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.16
-  version: v3.0.16
+  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.19
+  version: v3.0.19
 status: {}

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey545-nodey545
   labels:
     draft: draft-app
-    chart: "nodey545-3.0.16"
+    chart: "nodey545-3.0.19"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey545-nodey545
       containers:
         - name: nodey545
-          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.16"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.19"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 3.0.16
+              value: 3.0.19
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey545
   labels:
-    chart: "nodey545-3.0.16"
+    chart: "nodey545-3.0.19"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-rjvt6-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-rjvt6-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-ir6ro"
+  name: "jenkins-ui-test-rjvt6"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey545
-  version: 3.0.16
+  version: 3.0.19
   name: nodey545
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey545 to version 3.0.19

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge