### PR TITLE
chore: promote nodey545 to version 3.0.21

### DIFF
--- a/config-root/namespaces/jx-staging/nodey545/nodey545-3.0.21-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-3.0.21-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-12T11:22:25Z"
+  creationTimestamp: "2021-01-12T11:27:17Z"
   deletionTimestamp: null
-  name: 'nodey545-3.0.19'
+  name: 'nodey545-3.0.21'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 3.0.19
-      sha: 62022188ba36ffe8fca32486e485b59a3791cefb
+        chore: release 3.0.21
+      sha: 569da60902705eb2eef72ead1d290f6fbbdb2d28
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 201a5ce974dcacfcadfbde0f8ade2358ee305fcd
+      sha: a1867a71a9f27f055ed6402b9ed630c28c31dc28
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -39,11 +39,11 @@ spec:
         name: James Strachan
       message: |
         fix: avoid env
-      sha: eae60a2c47ee7e0a1b89e818355f3688c5237dbe
+      sha: e373bfce75576f6aede315d5527d17f48c2c6d96
   gitHttpUrl: https://github.com/jstrachan/nodey545
   gitOwner: jstrachan
   gitRepository: nodey545
   name: 'nodey545'
-  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.19
-  version: v3.0.19
+  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.21
+  version: v3.0.21
 status: {}

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey545-nodey545
   labels:
     draft: draft-app
-    chart: "nodey545-3.0.19"
+    chart: "nodey545-3.0.21"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey545-nodey545
       containers:
         - name: nodey545
-          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.19"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.21"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 3.0.19
+              value: 3.0.21
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey545
   labels:
-    chart: "nodey545-3.0.19"
+    chart: "nodey545-3.0.21"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-e5xks-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-e5xks-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-rjvt6"
+  name: "jenkins-ui-test-e5xks"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey545
-  version: 3.0.19
+  version: 3.0.21
   name: nodey545
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey545 to version 3.0.21

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge