### PR TITLE
chore: promote nodey545 to version 3.0.34

### DIFF
--- a/config-root/namespaces/jx-staging/nodey545/nodey545-3.0.34-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-3.0.34-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-12T14:25:20Z"
+  creationTimestamp: "2021-01-12T14:33:46Z"
   deletionTimestamp: null
-  name: 'nodey545-3.0.32'
+  name: 'nodey545-3.0.34'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 3.0.32
-      sha: 99871302e71ba47ca143bd219325d3424957ba7e
+        chore: release 3.0.34
+      sha: a706698905860c1ae064d396e831b9764cc4bf3d
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 9afc1aa3aab9bdbafda82d240be68942284723e9
+      sha: b88baa365893ae6b02bb063cebd2f3f6dafceebc
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -38,12 +38,12 @@ spec:
         email: james.strachan@gmail.com
         name: James Strachan
       message: |
-        fix: use GH pages
-      sha: 068e610159651f1c8a45694a43174a07050f73b0
+        fix: avoid explict path
+      sha: e51dd382478b38a5e76c08270fded967046da745
   gitHttpUrl: https://github.com/jstrachan/nodey545
   gitOwner: jstrachan
   gitRepository: nodey545
   name: 'nodey545'
-  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.32
-  version: v3.0.32
+  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.34
+  version: v3.0.34
 status: {}

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey545-nodey545
   labels:
     draft: draft-app
-    chart: "nodey545-3.0.32"
+    chart: "nodey545-3.0.34"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey545-nodey545
       containers:
         - name: nodey545
-          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.32"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.34"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 3.0.32
+              value: 3.0.34
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey545
   labels:
-    chart: "nodey545-3.0.32"
+    chart: "nodey545-3.0.34"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-93q5g-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-93q5g-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-d4eqk"
+  name: "jenkins-ui-test-93q5g"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey545
-  version: 3.0.32
+  version: 3.0.34
   name: nodey545
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey545 to version 3.0.34

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge