### PR TITLE
chore: promote nodey545 to version 3.0.43

### DIFF
--- a/config-root/namespaces/jx-staging/nodey545/nodey545-3.0.43-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-3.0.43-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-13T08:45:32Z"
+  creationTimestamp: "2021-01-13T08:57:02Z"
   deletionTimestamp: null
-  name: 'nodey545-3.0.41'
+  name: 'nodey545-3.0.43'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 3.0.41
-      sha: 31bce224f9f1296c42eb8b2199b46dd4def44f81
+        chore: release 3.0.43
+      sha: d00d09276dfa56374752374018c1378986088a2f
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: ab5ec82683cd5ad3cd266fd1076f9650c26c7064
+      sha: bc96e7699567652f1f76497bb372c8e825b5648b
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -38,12 +38,12 @@ spec:
         email: james.strachan@gmail.com
         name: James Strachan
       message: |
-        chore: try PR
-      sha: 319e1e30aed1ce10ec8032d6afb0baf1f5e25f27
+        chore: upgrade jx
+      sha: a1659ecabf5d87a5ea3cedae4340f7d3dad63099
   gitHttpUrl: https://github.com/jstrachan/nodey545
   gitOwner: jstrachan
   gitRepository: nodey545
   name: 'nodey545'
-  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.41
-  version: v3.0.41
+  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.43
+  version: v3.0.43
 status: {}

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey545-nodey545
   labels:
     draft: draft-app
-    chart: "nodey545-3.0.41"
+    chart: "nodey545-3.0.43"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey545-nodey545
       containers:
         - name: nodey545
-          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.41"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.43"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 3.0.41
+              value: 3.0.43
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey545
   labels:
-    chart: "nodey545-3.0.41"
+    chart: "nodey545-3.0.43"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-6mzac-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-6mzac-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-d9vyj"
+  name: "jenkins-ui-test-6mzac"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey545
-  version: 3.0.41
+  version: 3.0.43
   name: nodey545
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey545 to version 3.0.43

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge