### PR TITLE
chore: promote nodey545 to version 3.0.46

### DIFF
--- a/config-root/namespaces/jx-staging/nodey545/nodey545-3.0.46-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-3.0.46-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-13T08:57:02Z"
+  creationTimestamp: "2021-01-13T09:20:00Z"
   deletionTimestamp: null
-  name: 'nodey545-3.0.43'
+  name: 'nodey545-3.0.46'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 3.0.43
-      sha: d00d09276dfa56374752374018c1378986088a2f
+        chore: release 3.0.46
+      sha: c30dc38fa35182bb602fb179d7366e0ad45e6f07
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: bc96e7699567652f1f76497bb372c8e825b5648b
+      sha: 11266d498d7a2b9d10cad9b6dac3ce8302bcb96e
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -38,12 +38,12 @@ spec:
         email: james.strachan@gmail.com
         name: James Strachan
       message: |
-        chore: upgrade jx
-      sha: a1659ecabf5d87a5ea3cedae4340f7d3dad63099
+        chore: remove cruft
+      sha: 4649f3b552609a17b62e99daa2e5620945ad3c66
   gitHttpUrl: https://github.com/jstrachan/nodey545
   gitOwner: jstrachan
   gitRepository: nodey545
   name: 'nodey545'
-  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.43
-  version: v3.0.43
+  releaseNotesURL: https://github.com/jstrachan/nodey545/releases/tag/v3.0.46
+  version: v3.0.46
 status: {}

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-nodey545-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey545-nodey545
   labels:
     draft: draft-app
-    chart: "nodey545-3.0.43"
+    chart: "nodey545-3.0.46"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey545-nodey545
       containers:
         - name: nodey545
-          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.43"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey545:3.0.46"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 3.0.43
+              value: 3.0.46
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey545/nodey545-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey545
   labels:
-    chart: "nodey545-3.0.43"
+    chart: "nodey545-3.0.46"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-3sqci-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-3sqci-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-6mzac"
+  name: "jenkins-ui-test-3sqci"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey545
-  version: 3.0.43
+  version: 3.0.46
   name: nodey545
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey545 to version 3.0.46

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge