### PR TITLE
chore: promote nodey545 to version 3.0.51

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey545
-  version: 3.0.46
+  version: 3.0.51
   name: nodey545
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey545 to version 3.0.51

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge