### PR TITLE
chore: promote nodey553 to version 2.1.1

### DIFF
--- a/config-root/namespaces/jx-staging/nodey553/nodey553-2.1.1-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey553/nodey553-2.1.1-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-22T16:36:01Z"
+  creationTimestamp: "2021-01-22T16:40:25Z"
   deletionTimestamp: null
-  name: 'nodey553-2.0.1302'
+  name: 'nodey553-2.1.1'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 2.0.1302
-      sha: c149a5db4d1c1a1eead2992d3ffbc13a248ac873
+        chore: release 2.1.1
+      sha: 7725e6473790133ebdc94768a6c9c56074e785cd
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,21 +29,20 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 7b6e440023dfaa322908714d5608c223f2d7d1e3
+      sha: bcd276c6c08d00a194fae77a06e2af74aaabca57
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
       branch: master
       committer:
-        email: james.strachan@gmail.com
-        name: James Strachan
-      message: |
-        fix: update better uses
-      sha: 52ab1e8dea046c7036d3ed02da732f996bd7336e
+        email: noreply@github.com
+        name: GitHub
+      message: Update index.html
+      sha: a35182d291209635ff9a5ac781c58cc9f0b73b9f
   gitHttpUrl: https://github.com/jstrachan/nodey553
   gitOwner: jstrachan
   gitRepository: nodey553
   name: 'nodey553'
-  releaseNotesURL: https://github.com/jstrachan/nodey553/releases/tag/v2.0.1302
-  version: v2.0.1302
+  releaseNotesURL: https://github.com/jstrachan/nodey553/releases/tag/v2.1.1
+  version: v2.1.1
 status: {}

--- a/config-root/namespaces/jx-staging/nodey553/nodey553-nodey553-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey553/nodey553-nodey553-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey553-nodey553
   labels:
     draft: draft-app
-    chart: "nodey553-2.0.1302"
+    chart: "nodey553-2.1.1"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey553-nodey553
       containers:
         - name: nodey553
-          image: "gcr.io/jenkins-x-labs-bdd/nodey553:2.0.1302"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey553:2.1.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 2.0.1302
+              value: 2.1.1
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey553/nodey553-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey553/nodey553-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey553
   labels:
-    chart: "nodey553-2.0.1302"
+    chart: "nodey553-2.1.1"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-sg7f9-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-sg7f9-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-5zyyu"
+  name: "jenkins-ui-test-sg7f9"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -21,7 +21,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev2/nodey553
-  version: 2.0.1302
+  version: 2.1.1
   name: nodey553
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey553 to version 2.1.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
