### PR TITLE
chore: promote nodey553 to version 2.1.1

### DIFF
--- a/config-root/namespaces/jx-production/nodey553/nodey553-2.1.1-release.yaml
+++ b/config-root/namespaces/jx-production/nodey553/nodey553-2.1.1-release.yaml
@@ -1,0 +1,48 @@
+# Source: nodey553/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-01-22T16:40:25Z"
+  deletionTimestamp: null
+  name: 'nodey553-2.1.1'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 2.1.1
+      sha: 7725e6473790133ebdc94768a6c9c56074e785cd
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: bcd276c6c08d00a194fae77a06e2af74aaabca57
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: noreply@github.com
+        name: GitHub
+      message: Update index.html
+      sha: a35182d291209635ff9a5ac781c58cc9f0b73b9f
+  gitHttpUrl: https://github.com/jstrachan/nodey553
+  gitOwner: jstrachan
+  gitRepository: nodey553
+  name: 'nodey553'
+  releaseNotesURL: https://github.com/jstrachan/nodey553/releases/tag/v2.1.1
+  version: v2.1.1
+status: {}

--- a/config-root/namespaces/jx-production/nodey553/nodey553-ingress.yaml
+++ b/config-root/namespaces/jx-production/nodey553/nodey553-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: nodey553/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: nodey553
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey553
+              servicePort: 80
+      host: nodey553-jx-production.34.105.246.143.xip.io

--- a/config-root/namespaces/jx-production/nodey553/nodey553-nodey553-deploy.yaml
+++ b/config-root/namespaces/jx-production/nodey553/nodey553-nodey553-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: nodey553/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodey553-nodey553
+  labels:
+    draft: draft-app
+    chart: "nodey553-2.1.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nodey553-nodey553
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: nodey553-nodey553
+    spec:
+      serviceAccountName: nodey553-nodey553
+      containers:
+        - name: nodey553
+          image: "gcr.io/jenkins-x-labs-bdd/nodey553:2.1.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 2.1.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/nodey553/nodey553-nodey553-sa.yaml
+++ b/config-root/namespaces/jx-production/nodey553/nodey553-nodey553-sa.yaml
@@ -1,0 +1,8 @@
+# Source: nodey553/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nodey553-nodey553
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/nodey553/nodey553-svc.yaml
+++ b/config-root/namespaces/jx-production/nodey553/nodey553-svc.yaml
@@ -1,0 +1,21 @@
+# Source: nodey553/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey553
+  labels:
+    chart: "nodey553-2.1.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey553-nodey553

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-d3fyo-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-d3fyo-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-5zyyu"
+  name: "jenkins-ui-test-d3fyo"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -11,5 +11,7 @@ releases:
 - chart: dev/nodey553
   version: 2.1.1
   name: nodey553
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -4,5 +4,12 @@ environments:
     values:
     - jx-values.yaml
 namespace: jx-production
+repositories:
+- name: dev
+  url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
+releases:
+- chart: dev/nodey553
+  version: 2.1.1
+  name: nodey553
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey553 to version 2.1.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
