### PR TITLE
chore: promote nodey554 to version 1.0.22 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/nodey554/nodey554-1.0.22-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-1.0.22-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-01-19T14:23:56Z"
+  creationTimestamp: "2021-01-27T10:23:36Z"
   deletionTimestamp: null
-  name: 'nodey554-1.0.21'
+  name: 'nodey554-1.0.22'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.21
-      sha: c72dbfa4866bd6a7152cdcdd63dc8f6ec2ffce17
+        chore: release 1.0.22
+      sha: 6dfd93117bd991b2f78bc389e920c344b9ca25db
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,17 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 8a9bed67b836324a4f9528596e68954336b5a394
+      sha: 2831e5b7a269eee9794605df2eb72f4839c06f64
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      message: |
+        chore: upgrade pipelines
+      sha: fe3fe5d70f94d81039a77c1c1aa9a1d793cb12e0
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -38,11 +48,11 @@ spec:
         email: noreply@github.com
         name: GitHub
       message: Update index.html
-      sha: 906430eeff5042c3dc33cc352ae8cea875ff8271
+      sha: 35cb6735be61d04298b6545fb12102d89e948c12
   gitHttpUrl: https://github.com/jstrachan/nodey554
   gitOwner: jstrachan
   gitRepository: nodey554
   name: 'nodey554'
-  releaseNotesURL: https://github.com/jstrachan/nodey554/releases/tag/v1.0.21
-  version: v1.0.21
+  releaseNotesURL: https://github.com/jstrachan/nodey554/releases/tag/v1.0.22
+  version: v1.0.22
 status: {}

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-ksvc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey554
   labels:
-    chart: "nodey554-1.0.21"
+    chart: "nodey554-1.0.22"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
 spec:
@@ -14,11 +14,11 @@ spec:
         autoscaling.knative.dev/minScale: "0"
     spec:
       containers:
-        - image: "gcr.io/jenkins-x-labs-bdd/nodey554:1.0.21"
+        - image: "gcr.io/jenkins-x-labs-bdd/nodey554:1.0.22"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.21
+              value: 1.0.22
           livenessProbe:
             httpGet:
               path: /

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-0bbbf-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-0bbbf-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-x8qdo"
+  name: "jenkins-ui-test-0bbbf"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -11,7 +11,7 @@ repositories:
   url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
 releases:
 - chart: dev/nodey554
-  version: 1.0.21
+  version: 1.0.22
   name: nodey554
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey554 to version 1.0.22 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge