### PR TITLE
chore: promote bdd-gh-1612282705 to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-staging/bdd-gh-1612282705/bdd-gh-1612282705-bdd-gh-1612282705-deploy.yaml
+++ b/config-root/namespaces/jx-staging/bdd-gh-1612282705/bdd-gh-1612282705-bdd-gh-1612282705-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: bdd-gh-1612282705/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bdd-gh-1612282705-bdd-gh-1612282705
+  labels:
+    draft: draft-app
+    chart: "bdd-gh-1612282705-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: bdd-gh-1612282705-bdd-gh-1612282705
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: bdd-gh-1612282705-bdd-gh-1612282705
+    spec:
+      serviceAccountName: bdd-gh-1612282705-bdd-gh-1612282705
+      containers:
+        - name: bdd-gh-1612282705
+          image: "gcr.io/jenkins-x-labs-bdd/bdd-gh-1612282705:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/bdd-gh-1612282705/bdd-gh-1612282705-bdd-gh-1612282705-sa.yaml
+++ b/config-root/namespaces/jx-staging/bdd-gh-1612282705/bdd-gh-1612282705-bdd-gh-1612282705-sa.yaml
@@ -1,0 +1,8 @@
+# Source: bdd-gh-1612282705/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bdd-gh-1612282705-bdd-gh-1612282705
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/bdd-gh-1612282705/bdd-gh-1612282705-ingress.yaml
+++ b/config-root/namespaces/jx-staging/bdd-gh-1612282705/bdd-gh-1612282705-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: bdd-gh-1612282705/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: bdd-gh-1612282705
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: bdd-gh-1612282705
+              servicePort: 80
+      host: bdd-gh-1612282705-jx-staging.34.105.246.143.xip.io

--- a/config-root/namespaces/jx-staging/bdd-gh-1612282705/bdd-gh-1612282705-svc.yaml
+++ b/config-root/namespaces/jx-staging/bdd-gh-1612282705/bdd-gh-1612282705-svc.yaml
@@ -1,0 +1,21 @@
+# Source: bdd-gh-1612282705/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: bdd-gh-1612282705
+  labels:
+    chart: "bdd-gh-1612282705-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: bdd-gh-1612282705-bdd-gh-1612282705

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-h2wpx-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-h2wpx-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-qb4dj"
+  name: "jenkins-ui-test-h2wpx"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -4,5 +4,12 @@ environments:
     values:
     - jx-values.yaml
 namespace: jx-staging
+repositories:
+- name: dev
+  url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
+releases:
+- chart: dev/bdd-gh-1612282705
+  version: 0.0.1
+  name: bdd-gh-1612282705
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -11,5 +11,7 @@ releases:
 - chart: dev/bdd-gh-1612282705
   version: 0.0.1
   name: bdd-gh-1612282705
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote bdd-gh-1612282705 to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
