### PR TITLE
chore: promote bdd-gh-1612284286 to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-staging/bdd-gh-1612284286/bdd-gh-1612284286-bdd-gh-1612284286-deploy.yaml
+++ b/config-root/namespaces/jx-staging/bdd-gh-1612284286/bdd-gh-1612284286-bdd-gh-1612284286-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: bdd-gh-1612284286/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bdd-gh-1612284286-bdd-gh-1612284286
+  labels:
+    draft: draft-app
+    chart: "bdd-gh-1612284286-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: bdd-gh-1612284286-bdd-gh-1612284286
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: bdd-gh-1612284286-bdd-gh-1612284286
+    spec:
+      serviceAccountName: bdd-gh-1612284286-bdd-gh-1612284286
+      containers:
+        - name: bdd-gh-1612284286
+          image: "gcr.io/jenkins-x-labs-bdd/bdd-gh-1612284286:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/bdd-gh-1612284286/bdd-gh-1612284286-bdd-gh-1612284286-sa.yaml
+++ b/config-root/namespaces/jx-staging/bdd-gh-1612284286/bdd-gh-1612284286-bdd-gh-1612284286-sa.yaml
@@ -1,0 +1,8 @@
+# Source: bdd-gh-1612284286/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bdd-gh-1612284286-bdd-gh-1612284286
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/bdd-gh-1612284286/bdd-gh-1612284286-ingress.yaml
+++ b/config-root/namespaces/jx-staging/bdd-gh-1612284286/bdd-gh-1612284286-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: bdd-gh-1612284286/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: bdd-gh-1612284286
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: bdd-gh-1612284286
+              servicePort: 80
+      host: bdd-gh-1612284286-jx-staging.34.105.246.143.xip.io

--- a/config-root/namespaces/jx-staging/bdd-gh-1612284286/bdd-gh-1612284286-svc.yaml
+++ b/config-root/namespaces/jx-staging/bdd-gh-1612284286/bdd-gh-1612284286-svc.yaml
@@ -1,0 +1,21 @@
+# Source: bdd-gh-1612284286/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: bdd-gh-1612284286
+  labels:
+    chart: "bdd-gh-1612284286-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: bdd-gh-1612284286-bdd-gh-1612284286

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-bo7cg-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-bo7cg-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-n9vlr"
+  name: "jenkins-ui-test-bo7cg"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/bdd-gh-1612284286
   version: 0.0.1
   name: bdd-gh-1612284286
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: bdd-gh-1612282705
   values:
   - jx-values.yaml
+- chart: dev/bdd-gh-1612284286
+  version: 0.0.1
+  name: bdd-gh-1612284286
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote bdd-gh-1612284286 to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
