### PR TITLE
chore: promote rust-demo2 to version 0.0.1

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: bdd-gh-1612286898
   values:
   - jx-values.yaml
+- chart: dev/rust-demo2
+  version: 0.0.1
+  name: rust-demo2
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote rust-demo2 to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
