### PR TITLE
chore: promote rust-demo3 to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-0.0.2-release.yaml
+++ b/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-0.0.2-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-02-03T17:57:58Z"
+  creationTimestamp: "2021-02-03T18:07:01Z"
   deletionTimestamp: null
-  name: 'rust-demo3-0.0.1'
+  name: 'rust-demo3-0.0.2'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.1
-      sha: 769593f0d45844e048c8702a61ee60716bdb3e4e
+        chore: release 0.0.2
+      sha: 4576e62daeb3bc11bf7f50e881b1ae7b613127e8
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,17 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: e93935a15cc439da5ad1d8f7baea87b8359a07ea
+      sha: 477c92aff62c6b8aae9e537873540624a104818b
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      message: |
+        docs: typo
+      sha: 7c6ee7aea0ca82657d2e52a2501f0ee67698cbc5
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -39,21 +49,11 @@ spec:
         name: James Strachan
       message: |
         fix: pipeline
-      sha: 609b07785aade0ea0bcf8b6ae471f2f87cfd86f4
-    - author:
-        email: james.strachan@gmail.com
-        name: James Strachan
-      branch: master
-      committer:
-        email: james.strachan@gmail.com
-        name: James Strachan
-      message: |
-        chore: Jenkins X build pack
-      sha: 3c606afc0e219228882c4e7d635354cdc2869f46
+      sha: 24b119727ef2281d0ea9f2a4561d9a6d5b9af181
   gitHttpUrl: https://github.com/jstrachan/rust-demo3
   gitOwner: jstrachan
   gitRepository: rust-demo3
   name: 'rust-demo3'
-  releaseNotesURL: https://github.com/jstrachan/rust-demo3/releases/tag/v0.0.1
-  version: v0.0.1
+  releaseNotesURL: https://github.com/jstrachan/rust-demo3/releases/tag/v0.0.2
+  version: v0.0.2
 status: {}

--- a/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-rust-demo3-deploy.yaml
+++ b/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-rust-demo3-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: rust-demo3-rust-demo3
   labels:
     draft: draft-app
-    chart: "rust-demo3-0.0.1"
+    chart: "rust-demo3-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: rust-demo3-rust-demo3
       containers:
         - name: rust-demo3
-          image: "gcr.io/jenkins-x-labs-bdd/rust-demo3:0.0.1"
+          image: "gcr.io/jenkins-x-labs-bdd/rust-demo3:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.2
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-svc.yaml
+++ b/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: rust-demo3
   labels:
-    chart: "rust-demo3-0.0.1"
+    chart: "rust-demo3-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-iyri7-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-iyri7-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-orq2i"
+  name: "jenkins-ui-test-iyri7"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
 releases:
 - chart: dev/rust-demo3
-  version: 0.0.1
+  version: 0.0.2
   name: rust-demo3
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote rust-demo3 to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
