### PR TITLE
chore: promote rust-demo3 to version 0.0.3

### DIFF
--- a/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-0.0.3-release.yaml
+++ b/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-0.0.3-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-02-03T18:07:01Z"
+  creationTimestamp: "2021-02-04T07:26:47Z"
   deletionTimestamp: null
-  name: 'rust-demo3-0.0.2'
+  name: 'rust-demo3-0.0.3'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.2
-      sha: 4576e62daeb3bc11bf7f50e881b1ae7b613127e8
+        chore: release 0.0.3
+      sha: eecd2c96d50f067ec53e36c7750793eb6182e6e5
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 477c92aff62c6b8aae9e537873540624a104818b
+      sha: d32aaf048034e65198611a2d701dbdf46e1e658b
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -38,8 +38,8 @@ spec:
         email: james.strachan@gmail.com
         name: James Strachan
       message: |
-        docs: typo
-      sha: 7c6ee7aea0ca82657d2e52a2501f0ee67698cbc5
+        fix: rust image
+      sha: 2fc7884edbe1a9d31fb1dc0e8a96a20f1452161d
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -48,12 +48,12 @@ spec:
         email: james.strachan@gmail.com
         name: James Strachan
       message: |
-        fix: pipeline
-      sha: 24b119727ef2281d0ea9f2a4561d9a6d5b9af181
+        fix: rust
+      sha: fbd22cf576b4f454109dacced34b9c0394e54b6d
   gitHttpUrl: https://github.com/jstrachan/rust-demo3
   gitOwner: jstrachan
   gitRepository: rust-demo3
   name: 'rust-demo3'
-  releaseNotesURL: https://github.com/jstrachan/rust-demo3/releases/tag/v0.0.2
-  version: v0.0.2
+  releaseNotesURL: https://github.com/jstrachan/rust-demo3/releases/tag/v0.0.3
+  version: v0.0.3
 status: {}

--- a/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-rust-demo3-deploy.yaml
+++ b/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-rust-demo3-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: rust-demo3-rust-demo3
   labels:
     draft: draft-app
-    chart: "rust-demo3-0.0.2"
+    chart: "rust-demo3-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: rust-demo3-rust-demo3
       containers:
         - name: rust-demo3
-          image: "gcr.io/jenkins-x-labs-bdd/rust-demo3:0.0.2"
+          image: "gcr.io/jenkins-x-labs-bdd/rust-demo3:0.0.3"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.2
+              value: 0.0.3
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-svc.yaml
+++ b/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: rust-demo3
   labels:
-    chart: "rust-demo3-0.0.2"
+    chart: "rust-demo3-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-menp5-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-menp5-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-iyri7"
+  name: "jenkins-ui-test-menp5"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
 releases:
 - chart: dev/rust-demo3
-  version: 0.0.2
+  version: 0.0.3
   name: rust-demo3
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote rust-demo3 to version 0.0.3

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
