### PR TITLE
chore: promote rust-demo3 to version 0.0.5

### DIFF
--- a/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-0.0.5-release.yaml
+++ b/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-0.0.5-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-02-04T10:57:10Z"
+  creationTimestamp: "2021-02-04T11:22:18Z"
   deletionTimestamp: null
-  name: 'rust-demo3-0.0.4'
+  name: 'rust-demo3-0.0.5'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.4
-      sha: 0cd5e2fcd9313841f0fbaed875a40434ff0391df
+        chore: release 0.0.5
+      sha: 907695cfd8f2ac025208a7000b1e19c34d356eb3
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,11 +29,11 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 8e9c69686178415b659226bdffac021baaf27f9c
+      sha: b315ae7c16d2d37ee243ae37a817103ca0a78376
   gitHttpUrl: https://github.com/jstrachan/rust-demo3
   gitOwner: jstrachan
   gitRepository: rust-demo3
   name: 'rust-demo3'
-  releaseNotesURL: https://github.com/jstrachan/rust-demo3/releases/tag/v0.0.4
-  version: v0.0.4
+  releaseNotesURL: https://github.com/jstrachan/rust-demo3/releases/tag/v0.0.5
+  version: v0.0.5
 status: {}

--- a/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-rust-demo3-deploy.yaml
+++ b/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-rust-demo3-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: rust-demo3-rust-demo3
   labels:
     draft: draft-app
-    chart: "rust-demo3-0.0.4"
+    chart: "rust-demo3-0.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: rust-demo3-rust-demo3
       containers:
         - name: rust-demo3
-          image: "gcr.io/jenkins-x-labs-bdd/rust-demo3:0.0.4"
+          image: "gcr.io/jenkins-x-labs-bdd/rust-demo3:0.0.5"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.4
+              value: 0.0.5
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-svc.yaml
+++ b/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: rust-demo3
   labels:
-    chart: "rust-demo3-0.0.4"
+    chart: "rust-demo3-0.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-98bbp-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-98bbp-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-zoa2n"
+  name: "jenkins-ui-test-98bbp"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
 releases:
 - chart: dev/rust-demo3
-  version: 0.0.4
+  version: 0.0.5
   name: rust-demo3
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote rust-demo3 to version 0.0.5

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
