### PR TITLE
chore: promote rust-demo3 to version 0.0.5

### DIFF
--- a/config-root/namespaces/jx-production/rust-demo3/rust-demo3-0.0.5-release.yaml
+++ b/config-root/namespaces/jx-production/rust-demo3/rust-demo3-0.0.5-release.yaml
@@ -1,0 +1,39 @@
+# Source: rust-demo3/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-02-04T11:22:18Z"
+  deletionTimestamp: null
+  name: 'rust-demo3-0.0.5'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.5
+      sha: 907695cfd8f2ac025208a7000b1e19c34d356eb3
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: b315ae7c16d2d37ee243ae37a817103ca0a78376
+  gitHttpUrl: https://github.com/jstrachan/rust-demo3
+  gitOwner: jstrachan
+  gitRepository: rust-demo3
+  name: 'rust-demo3'
+  releaseNotesURL: https://github.com/jstrachan/rust-demo3/releases/tag/v0.0.5
+  version: v0.0.5
+status: {}

--- a/config-root/namespaces/jx-production/rust-demo3/rust-demo3-ingress.yaml
+++ b/config-root/namespaces/jx-production/rust-demo3/rust-demo3-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: rust-demo3/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: rust-demo3
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: rust-demo3
+              servicePort: 80
+      host: rust-demo3-jx-production.34.105.246.143.xip.io

--- a/config-root/namespaces/jx-production/rust-demo3/rust-demo3-rust-demo3-deploy.yaml
+++ b/config-root/namespaces/jx-production/rust-demo3/rust-demo3-rust-demo3-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: rust-demo3/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rust-demo3-rust-demo3
+  labels:
+    draft: draft-app
+    chart: "rust-demo3-0.0.5"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: rust-demo3-rust-demo3
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: rust-demo3-rust-demo3
+    spec:
+      serviceAccountName: rust-demo3-rust-demo3
+      containers:
+        - name: rust-demo3
+          image: "gcr.io/jenkins-x-labs-bdd/rust-demo3:0.0.5"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.5
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/rust-demo3/rust-demo3-rust-demo3-sa.yaml
+++ b/config-root/namespaces/jx-production/rust-demo3/rust-demo3-rust-demo3-sa.yaml
@@ -1,0 +1,8 @@
+# Source: rust-demo3/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rust-demo3-rust-demo3
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/rust-demo3/rust-demo3-svc.yaml
+++ b/config-root/namespaces/jx-production/rust-demo3/rust-demo3-svc.yaml
@@ -1,0 +1,21 @@
+# Source: rust-demo3/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: rust-demo3
+  labels:
+    chart: "rust-demo3-0.0.5"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: rust-demo3-rust-demo3

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-79gae-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-79gae-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-zoa2n"
+  name: "jenkins-ui-test-79gae"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -4,5 +4,12 @@ environments:
     values:
     - jx-values.yaml
 namespace: jx-production
+repositories:
+- name: dev
+  url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
+releases:
+- chart: dev/rust-demo3
+  version: 0.0.5
+  name: rust-demo3
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -11,5 +11,7 @@ releases:
 - chart: dev/rust-demo3
   version: 0.0.5
   name: rust-demo3
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote rust-demo3 to version 0.0.5

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
