### PR TITLE
chore: promote nodey554 to version 1.0.23

### DIFF
--- a/config-root/namespaces/jx-staging/nodey554/nodey554-ksvc.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-ksvc.yaml
@@ -1,0 +1,42 @@
+# Source: nodey554/templates/ksvc.yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: nodey554
+  labels:
+    chart: "nodey554-1.0.23"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "0"
+    spec:
+      containers:
+        - image: "gcr.io/jenkins-x-labs-bdd/nodey554:1.0.23"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 1.0.23
+          livenessProbe:
+            httpGet:
+              path: /
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 1
+            httpGet:
+              path: /
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-nodey554-sa.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-nodey554-sa.yaml
@@ -1,0 +1,8 @@
+# Source: nodey554/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nodey554-nodey554
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-c1zfy-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-c1zfy-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-e3w08"
+  name: "jenkins-ui-test-c1zfy"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: rust-demo3
   values:
   - jx-values.yaml
+- chart: dev/nodey554
+  version: 1.0.23
+  name: nodey554
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/nodey554
   version: 1.0.23
   name: nodey554
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey554 to version 1.0.23

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
