### PR TITLE
chore: promote nodey546 to version 1.0.4

### DIFF
--- a/config-root/namespaces/jx-staging/nodey546/nodey546-1.0.4-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-1.0.4-release.yaml
@@ -1,0 +1,48 @@
+# Source: nodey546/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-02-18T10:28:35Z"
+  deletionTimestamp: null
+  name: 'nodey546-1.0.4'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 1.0.4
+      sha: a457edee5fd898507b326c930d08681ebeb34de8
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 2c80cdc5d461ee413190efe8a3c995f54ebbb731
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: noreply@github.com
+        name: GitHub
+      message: Update index.html
+      sha: 1c5bbab4b77090dec694d18f33df71f1fbfa6ca0
+  gitHttpUrl: https://github.com/jstrachan/nodey546
+  gitOwner: jstrachan
+  gitRepository: nodey546
+  name: 'nodey546'
+  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.4
+  version: v1.0.4
+status: {}

--- a/config-root/namespaces/jx-staging/nodey546/nodey546-ingress.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: nodey546/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: nodey546
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey546
+              servicePort: 80
+      host: nodey546-jx-staging.34.105.246.143.xip.io

--- a/config-root/namespaces/jx-staging/nodey546/nodey546-nodey546-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-nodey546-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: nodey546/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodey546-nodey546
+  labels:
+    draft: draft-app
+    chart: "nodey546-1.0.4"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nodey546-nodey546
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: nodey546-nodey546
+    spec:
+      serviceAccountName: nodey546-nodey546
+      containers:
+        - name: nodey546
+          image: "gcr.io/jenkins-x-labs-bdd/nodey546:1.0.4"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 1.0.4
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/nodey546/nodey546-nodey546-sa.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-nodey546-sa.yaml
@@ -1,0 +1,8 @@
+# Source: nodey546/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nodey546-nodey546
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/nodey546/nodey546-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-svc.yaml
@@ -1,0 +1,21 @@
+# Source: nodey546/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey546
+  labels:
+    chart: "nodey546-1.0.4"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey546-nodey546

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-vkou9-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-vkou9-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-e3w08"
+  name: "jenkins-ui-test-vkou9"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/nodey546
   version: 1.0.4
   name: nodey546
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: rust-demo3
   values:
   - jx-values.yaml
+- chart: dev/nodey546
+  version: 1.0.4
+  name: nodey546
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey546 to version 1.0.4

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
