### PR TITLE
chore: promote nodey546 to version 1.0.6

### DIFF
--- a/config-root/namespaces/jx-staging/nodey546/nodey546-1.0.6-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-1.0.6-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-02-18T16:23:53Z"
+  creationTimestamp: "2021-02-22T10:12:24Z"
   deletionTimestamp: null
-  name: 'nodey546-1.0.5'
+  name: 'nodey546-1.0.6'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.5
-      sha: 2d3df632e4dd7d0fcb4d022679b563a9b0508862
+        chore: release 1.0.6
+      sha: 241e28b3650abca20956717940793b7ac1c4ec2e
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 0a7d4ca01c4551b2b85a9310431948c5bca0bcbb
+      sha: c28eca6f19ea76cf558aad4e2f270854391e12e2
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -38,11 +38,11 @@ spec:
         email: noreply@github.com
         name: GitHub
       message: Update index.html
-      sha: 1db4c4a68413aa33b086076d408b26481bcee00c
+      sha: 9b1daf8b6800d769ca188fb3340dd0c09874d144
   gitHttpUrl: https://github.com/jstrachan/nodey546
   gitOwner: jstrachan
   gitRepository: nodey546
   name: 'nodey546'
-  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.5
-  version: v1.0.5
+  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.6
+  version: v1.0.6
 status: {}

--- a/config-root/namespaces/jx-staging/nodey546/nodey546-nodey546-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-nodey546-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey546-nodey546
   labels:
     draft: draft-app
-    chart: "nodey546-1.0.5"
+    chart: "nodey546-1.0.6"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey546-nodey546
       containers:
         - name: nodey546
-          image: "gcr.io/jenkins-x-labs-bdd/nodey546:1.0.5"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey546:1.0.6"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.5
+              value: 1.0.6
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey546/nodey546-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey546
   labels:
-    chart: "nodey546-1.0.5"
+    chart: "nodey546-1.0.6"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-qyp7a-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-qyp7a-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-6gyfi"
+  name: "jenkins-ui-test-qyp7a"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -19,7 +19,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey546
-  version: 1.0.5
+  version: 1.0.6
   name: nodey546
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey546 to version 1.0.6

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
