### PR TITLE
chore: promote rust-demo3 to version 0.0.10

### DIFF
--- a/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-0.0.10-release.yaml
+++ b/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-0.0.10-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-02-22T10:25:30Z"
+  creationTimestamp: "2021-02-22T10:34:05Z"
   deletionTimestamp: null
-  name: 'rust-demo3-0.0.9'
+  name: 'rust-demo3-0.0.10'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.9
-      sha: 885e9d16516afe43a2b56c53820eacd3816676cc
+        chore: release 0.0.10
+      sha: c6dc6d57f05961b0cd0edfa174d535153e49e1a6
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,16 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 22e63c8d10ac02ae5d4fc4c5903ad473d4b83879
-    - author:
-        email: james.strachan@gmail.com
-        name: James Strachan
-      branch: master
-      committer:
-        email: noreply@github.com
-        name: GitHub
-      message: 'fix: avoid failing'
-      sha: a1488002132d04ea68913a39dadbe172d8725779
+      sha: 13fa02396de2e2f1bb1abb08c7e23d75be4cdef4
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -47,11 +38,11 @@ spec:
         email: noreply@github.com
         name: GitHub
       message: Update Dockerfile
-      sha: e73b760fbd1efce5960e860c3ff0105f469a44a2
+      sha: 72dbc7fe26c9fe03f6cf734e17945948d940a5e8
   gitHttpUrl: https://github.com/jstrachan/rust-demo3
   gitOwner: jstrachan
   gitRepository: rust-demo3
   name: 'rust-demo3'
-  releaseNotesURL: https://github.com/jstrachan/rust-demo3/releases/tag/v0.0.9
-  version: v0.0.9
+  releaseNotesURL: https://github.com/jstrachan/rust-demo3/releases/tag/v0.0.10
+  version: v0.0.10
 status: {}

--- a/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-rust-demo3-deploy.yaml
+++ b/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-rust-demo3-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: rust-demo3-rust-demo3
   labels:
     draft: draft-app
-    chart: "rust-demo3-0.0.9"
+    chart: "rust-demo3-0.0.10"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: rust-demo3-rust-demo3
       containers:
         - name: rust-demo3
-          image: "gcr.io/jenkins-x-labs-bdd/rust-demo3:0.0.9"
+          image: "gcr.io/jenkins-x-labs-bdd/rust-demo3:0.0.10"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.9
+              value: 0.0.10
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-svc.yaml
+++ b/config-root/namespaces/jx-staging/rust-demo3/rust-demo3-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: rust-demo3
   labels:
-    chart: "rust-demo3-0.0.9"
+    chart: "rust-demo3-0.0.10"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-1kpeu-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-1kpeu-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-jgsq2"
+  name: "jenkins-ui-test-1kpeu"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
 releases:
 - chart: dev/rust-demo3
-  version: 0.0.9
+  version: 0.0.10
   name: rust-demo3
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote rust-demo3 to version 0.0.10

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
