### PR TITLE
chore: promote nodey545 to version 3.0.62

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,6 +7,8 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
+- name: dev2
+  url: https://jstrachan.github.io/nodey545/
 releases:
 - chart: dev/rust-demo3
   version: 0.0.10
@@ -23,5 +25,8 @@ releases:
   name: nodey546
   values:
   - jx-values.yaml
+- chart: dev2/nodey545
+  version: 3.0.62
+  name: nodey545
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey545 to version 3.0.62

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
