### PR TITLE
chore: promote nodey545 to version 3.0.64

### DIFF
--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -4,5 +4,12 @@ environments:
     values:
     - jx-values.yaml
 namespace: jx-production
+repositories:
+- name: dev
+  url: https://jstrachan.github.io/nodey545/
+releases:
+- chart: dev/nodey545
+  version: 3.0.64
+  name: nodey545
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey545 to version 3.0.64

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
