### PR TITLE
chore: promote nodey546 to version 1.0.8

### DIFF
--- a/config-root/namespaces/jx-staging/nodey546/nodey546-1.0.8-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-1.0.8-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-03-01T10:52:53Z"
+  creationTimestamp: "2021-03-01T10:56:58Z"
   deletionTimestamp: null
-  name: 'nodey546-1.0.7'
+  name: 'nodey546-1.0.8'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.7
-      sha: f0df92477ea09f9bb28fa2c83aa4368f76d34342
+        chore: release 1.0.8
+      sha: 1cdf148da8e891693c047055796f69ccb0503212
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,11 +29,11 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 65e352358d4a19dc239d7b097d1a33f747d12085
+      sha: 073c949e25dad52579250cb1fb8e54512859b3f4
   gitHttpUrl: https://github.com/jstrachan/nodey546
   gitOwner: jstrachan
   gitRepository: nodey546
   name: 'nodey546'
-  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.7
-  version: v1.0.7
+  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.8
+  version: v1.0.8
 status: {}

--- a/config-root/namespaces/jx-staging/nodey546/nodey546-nodey546-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-nodey546-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey546-nodey546
   labels:
     draft: draft-app
-    chart: "nodey546-1.0.7"
+    chart: "nodey546-1.0.8"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey546-nodey546
       containers:
         - name: nodey546
-          image: "gcr.io/jenkins-x-labs-bdd/nodey546:1.0.7"
+          image: "gcr.io/jenkins-x-labs-bdd/nodey546:1.0.8"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.7
+              value: 1.0.8
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey546/nodey546-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey546
   labels:
-    chart: "nodey546-1.0.7"
+    chart: "nodey546-1.0.8"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/jx/rabbitmq/rabbitmq-statefulset.yaml
+++ b/config-root/namespaces/jx/rabbitmq/rabbitmq-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
       annotations:
         checksum/config: 8d47bdd060a173e0ec43c550f3375f7d602678010e7448ebeb1b1656adeca9fd
-        checksum/secret: 3e6e2c713c9ecab098847f3bf2c4e9a55f9b8f1adc2f59e637b3926df78421ea
+        checksum/secret: 14bc977877c1e6eb7047d6db3059b90da03b4b86cb625cc74631bb32626f95fd
     spec:
       serviceAccountName: rabbitmq
       affinity:

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-0kels-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-0kels-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-4kkqv"
+  name: "jenkins-ui-test-0kels"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -19,7 +19,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey546
-  version: 1.0.7
+  version: 1.0.8
   name: nodey546
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey546 to version 1.0.8

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
