### PR TITLE
chore: promote nodey546 to version 1.0.10

### DIFF
--- a/config-root/namespaces/jx-production/nodey546/nodey546-1.0.10-release.yaml
+++ b/config-root/namespaces/jx-production/nodey546/nodey546-1.0.10-release.yaml
@@ -1,0 +1,39 @@
+# Source: nodey546/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-03-01T11:28:02Z"
+  deletionTimestamp: null
+  name: 'nodey546-1.0.10'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 1.0.10
+      sha: 55c3cb7f203385819f7ee2d8cddbf1ffb56fe97b
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: fedf79680e1deb5c83d950626849e01ca09ee151
+  gitHttpUrl: https://github.com/jstrachan/nodey546
+  gitOwner: jstrachan
+  gitRepository: nodey546
+  name: 'nodey546'
+  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.10
+  version: v1.0.10
+status: {}

--- a/config-root/namespaces/jx-production/nodey546/nodey546-ingress.yaml
+++ b/config-root/namespaces/jx-production/nodey546/nodey546-ingress.yaml
@@ -1,0 +1,20 @@
+# Source: nodey546/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    beer: stella
+    wine: shiraz
+  name: nodey546
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey546
+              servicePort: 80
+      host: nodey546-jx-production.34.105.246.143.xip.io

--- a/config-root/namespaces/jx-production/nodey546/nodey546-nodey546-deploy.yaml
+++ b/config-root/namespaces/jx-production/nodey546/nodey546-nodey546-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: nodey546/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodey546-nodey546
+  labels:
+    draft: draft-app
+    chart: "nodey546-1.0.10"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nodey546-nodey546
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: nodey546-nodey546
+    spec:
+      serviceAccountName: nodey546-nodey546
+      containers:
+        - name: nodey546
+          image: "gcr.io/jenkins-x-labs-bdd/nodey546:1.0.10"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 1.0.10
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/nodey546/nodey546-nodey546-sa.yaml
+++ b/config-root/namespaces/jx-production/nodey546/nodey546-nodey546-sa.yaml
@@ -1,0 +1,8 @@
+# Source: nodey546/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nodey546-nodey546
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/nodey546/nodey546-svc.yaml
+++ b/config-root/namespaces/jx-production/nodey546/nodey546-svc.yaml
@@ -1,0 +1,21 @@
+# Source: nodey546/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey546
+  labels:
+    chart: "nodey546-1.0.10"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey546-nodey546

--- a/config-root/namespaces/jx/rabbitmq/rabbitmq-statefulset.yaml
+++ b/config-root/namespaces/jx/rabbitmq/rabbitmq-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
       annotations:
         checksum/config: 8d47bdd060a173e0ec43c550f3375f7d602678010e7448ebeb1b1656adeca9fd
-        checksum/secret: 14bc977877c1e6eb7047d6db3059b90da03b4b86cb625cc74631bb32626f95fd
+        checksum/secret: 27341444cdda9d1e48ab30830df337449c331785c121330fdee73ea8f0b147b6
     spec:
       serviceAccountName: rabbitmq
       affinity:

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-cmr0j-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-cmr0j-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-0kels"
+  name: "jenkins-ui-test-cmr0j"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -11,5 +11,7 @@ releases:
 - chart: dev/nodey546
   version: 1.0.10
   name: nodey546
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -4,5 +4,12 @@ environments:
     values:
     - jx-values.yaml
 namespace: jx-production
+repositories:
+- name: dev
+  url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
+releases:
+- chart: dev/nodey546
+  version: 1.0.10
+  name: nodey546
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey546 to version 1.0.10

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
