### PR TITLE
chore: promote rust-demo3 to version 0.0.12

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -4,5 +4,12 @@ environments:
     values:
     - jx-values.yaml
 namespace: jx-staging
+repositories:
+- name: dev
+  url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
+releases:
+- chart: dev/rust-demo3
+  version: 0.0.12
+  name: rust-demo3
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote rust-demo3 to version 0.0.12

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
