### PR TITLE
chore: promote nodey554 to version 1.0.27

### DIFF
--- a/config-root/namespaces/jx-staging/nodey554/nodey554-1.0.27-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-1.0.27-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-03-09T05:57:46Z"
+  creationTimestamp: "2021-03-09T06:04:35Z"
   deletionTimestamp: null
-  name: 'nodey554-1.0.26'
+  name: 'nodey554-1.0.27'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.26
-      sha: 1bef54bb3d047400f6cb63a8172f965967718592
+        chore: release 1.0.27
+      sha: b3e1c27add734585df8a0407e22996f087435a3a
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 76872c52eb38e5bf7cdab3d9f2914c6bb8b55898
+      sha: 66fcf78e8b2b34adac52149946140c9046ffa3c3
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -37,12 +37,12 @@ spec:
       committer:
         email: noreply@github.com
         name: GitHub
-      message: Update index.html
-      sha: 60eb6364318ddeae08f7e280036ae1eea326482c
+      message: Update values.yaml
+      sha: 7f0fa1fb4e8409b86a6c28e6cbb857ed99b1de08
   gitHttpUrl: https://github.com/jstrachan/nodey554
   gitOwner: jstrachan
   gitRepository: nodey554
   name: 'nodey554'
-  releaseNotesURL: https://github.com/jstrachan/nodey554/releases/tag/v1.0.26
-  version: v1.0.26
+  releaseNotesURL: https://github.com/jstrachan/nodey554/releases/tag/v1.0.27
+  version: v1.0.27
 status: {}

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-ingress.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: nodey554/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: nodey554
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey554
+              servicePort: 80
+      host: nodey554-jx-staging.34.89.8.12.nip.io

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-nodey554-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-nodey554-deploy.yaml
@@ -1,35 +1,49 @@
-# Source: nodey554/templates/ksvc.yaml
-apiVersion: serving.knative.dev/v1
-kind: Service
+# Source: nodey554/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: nodey554
+  name: nodey554-nodey554
   labels:
-    chart: "nodey554-1.0.26"
+    draft: draft-app
+    chart: "nodey554-1.0.27"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
 spec:
+  selector:
+    matchLabels:
+      app: nodey554-nodey554
+  replicas: 1
   template:
     metadata:
-      annotations:
-        autoscaling.knative.dev/minScale: "0"
+      labels:
+        draft: draft-app
+        app: nodey554-nodey554
     spec:
+      serviceAccountName: nodey554-nodey554
       containers:
-        - image: "gcr.io/jenkins-x-labs-bdd1/nodey554:1.0.26"
+        - name: nodey554
+          image: "gcr.io/jenkins-x-labs-bdd1/nodey554:1.0.27"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.26
+              value: 1.0.27
+          envFrom: null
+          ports:
+            - containerPort: 8080
           livenessProbe:
             httpGet:
               path: /
+              port: 8080
             initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
           readinessProbe:
-            failureThreshold: 1
             httpGet:
               path: /
+              port: 8080
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -40,3 +54,5 @@ spec:
             requests:
               cpu: 200m
               memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/nodey554/nodey554-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey554/nodey554-svc.yaml
@@ -1,0 +1,21 @@
+# Source: nodey554/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey554
+  labels:
+    chart: "nodey554-1.0.27"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey554-nodey554

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey554
-  version: 1.0.26
+  version: 1.0.27
   name: nodey554
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey554 to version 1.0.27

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
