### PR TITLE
chore: promote nodey554 to version 1.0.27

### DIFF
--- a/config-root/namespaces/jx-production/nodey554/nodey554-1.0.27-release.yaml
+++ b/config-root/namespaces/jx-production/nodey554/nodey554-1.0.27-release.yaml
@@ -1,0 +1,48 @@
+# Source: nodey554/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-03-09T06:04:35Z"
+  deletionTimestamp: null
+  name: 'nodey554-1.0.27'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 1.0.27
+      sha: b3e1c27add734585df8a0407e22996f087435a3a
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 66fcf78e8b2b34adac52149946140c9046ffa3c3
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: noreply@github.com
+        name: GitHub
+      message: Update values.yaml
+      sha: 7f0fa1fb4e8409b86a6c28e6cbb857ed99b1de08
+  gitHttpUrl: https://github.com/jstrachan/nodey554
+  gitOwner: jstrachan
+  gitRepository: nodey554
+  name: 'nodey554'
+  releaseNotesURL: https://github.com/jstrachan/nodey554/releases/tag/v1.0.27
+  version: v1.0.27
+status: {}

--- a/config-root/namespaces/jx-production/nodey554/nodey554-ingress.yaml
+++ b/config-root/namespaces/jx-production/nodey554/nodey554-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: nodey554/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: nodey554
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey554
+              servicePort: 80
+      host: nodey554-jx-production.34.89.8.12.nip.io

--- a/config-root/namespaces/jx-production/nodey554/nodey554-nodey554-deploy.yaml
+++ b/config-root/namespaces/jx-production/nodey554/nodey554-nodey554-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: nodey554/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodey554-nodey554
+  labels:
+    draft: draft-app
+    chart: "nodey554-1.0.27"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nodey554-nodey554
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: nodey554-nodey554
+    spec:
+      serviceAccountName: nodey554-nodey554
+      containers:
+        - name: nodey554
+          image: "gcr.io/jenkins-x-labs-bdd1/nodey554:1.0.27"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 1.0.27
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/nodey554/nodey554-nodey554-sa.yaml
+++ b/config-root/namespaces/jx-production/nodey554/nodey554-nodey554-sa.yaml
@@ -1,0 +1,8 @@
+# Source: nodey554/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nodey554-nodey554
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/nodey554/nodey554-svc.yaml
+++ b/config-root/namespaces/jx-production/nodey554/nodey554-svc.yaml
@@ -1,0 +1,21 @@
+# Source: nodey554/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey554
+  labels:
+    chart: "nodey554-1.0.27"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey554-nodey554

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/nodey554
   version: 1.0.27
   name: nodey554
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: nodey560
   values:
   - jx-values.yaml
+- chart: dev/nodey554
+  version: 1.0.27
+  name: nodey554
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey554 to version 1.0.27

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
