### PR TITLE
chore: promote nodey560 to version 0.0.3

### DIFF
--- a/config-root/namespaces/jx-staging/nodey560/nodey560-0.0.3-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey560/nodey560-0.0.3-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-03-09T05:45:09Z"
+  creationTimestamp: "2021-03-17T10:32:59Z"
   deletionTimestamp: null
-  name: 'nodey560-0.0.2'
+  name: 'nodey560-0.0.3'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.2
-      sha: 01292192f7d0cc887d0a6fe0b3782d2344f71625
+        chore: release 0.0.3
+      sha: 62739ab785880588978333f69b685963f7f1c337
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 1b654e3e72fffdc3a57bb42f10c9bf7d1466c1e9
+      sha: 37fa56b79438b3ff725abc70db9e2557d5920c59
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -38,11 +38,11 @@ spec:
         email: noreply@github.com
         name: GitHub
       message: Update index.html
-      sha: a2294806bfa277c717f028ee53577f360d3bdd55
+      sha: 0acef6c68498b5ce3bdc6bf23e545ac2c5b49809
   gitHttpUrl: https://github.com/jstrachan/nodey560
   gitOwner: jstrachan
   gitRepository: nodey560
   name: 'nodey560'
-  releaseNotesURL: https://github.com/jstrachan/nodey560/releases/tag/v0.0.2
-  version: v0.0.2
+  releaseNotesURL: https://github.com/jstrachan/nodey560/releases/tag/v0.0.3
+  version: v0.0.3
 status: {}

--- a/config-root/namespaces/jx-staging/nodey560/nodey560-nodey560-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey560/nodey560-nodey560-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey560-nodey560
   labels:
     draft: draft-app
-    chart: "nodey560-0.0.2"
+    chart: "nodey560-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey560-nodey560
       containers:
         - name: nodey560
-          image: "gcr.io/jenkins-x-labs-bdd1/nodey560:0.0.2"
+          image: "gcr.io/jenkins-x-labs-bdd1/nodey560:0.0.3"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.2
+              value: 0.0.3
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/nodey560/nodey560-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey560/nodey560-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey560
   labels:
-    chart: "nodey560-0.0.2"
+    chart: "nodey560-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
 spec:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
 releases:
 - chart: dev/nodey560
-  version: 0.0.2
+  version: 0.0.3
   name: nodey560
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey560 to version 0.0.3

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
