### PR TITLE
chore: promote nodey560 to version 0.0.5

### DIFF
--- a/config-root/namespaces/jx-staging/nodey560/nodey560-0.0.5-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey560/nodey560-0.0.5-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-03-17T10:32:59Z"
+  creationTimestamp: "2021-03-17T12:24:40Z"
   deletionTimestamp: null
-  name: 'nodey560-0.0.3'
+  name: 'nodey560-0.0.5'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.3
-      sha: 62739ab785880588978333f69b685963f7f1c337
+        chore: release 0.0.5
+      sha: 38f6988125c9729cdaeb8f6ef8186b4358d1f54a
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,20 +29,21 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 37fa56b79438b3ff725abc70db9e2557d5920c59
+      sha: 7631558b44eda27ff9a29cd975796a9941dc8f4a
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
       branch: master
       committer:
-        email: noreply@github.com
-        name: GitHub
-      message: Update index.html
-      sha: 0acef6c68498b5ce3bdc6bf23e545ac2c5b49809
+        email: james.strachan@gmail.com
+        name: James Strachan
+      message: |
+        fix: upgrade promote
+      sha: ffa56ef555498ad8579b51fac4540de47efa4111
   gitHttpUrl: https://github.com/jstrachan/nodey560
   gitOwner: jstrachan
   gitRepository: nodey560
   name: 'nodey560'
-  releaseNotesURL: https://github.com/jstrachan/nodey560/releases/tag/v0.0.3
-  version: v0.0.3
+  releaseNotesURL: https://github.com/jstrachan/nodey560/releases/tag/v0.0.5
+  version: v0.0.5
 status: {}

--- a/config-root/namespaces/jx-staging/nodey560/nodey560-nodey560-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey560/nodey560-nodey560-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey560-nodey560
   labels:
     draft: draft-app
-    chart: "nodey560-0.0.3"
+    chart: "nodey560-0.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey560-nodey560
       containers:
         - name: nodey560
-          image: "gcr.io/jenkins-x-labs-bdd1/nodey560:0.0.3"
+          image: "gcr.io/jenkins-x-labs-bdd1/nodey560:0.0.5"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.3
+              value: 0.0.5
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/nodey560/nodey560-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey560/nodey560-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey560
   labels:
-    chart: "nodey560-0.0.3"
+    chart: "nodey560-0.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
 spec:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
 releases:
 - chart: dev/nodey560
-  version: 0.0.3
+  version: 0.0.5
   name: nodey560
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey560 to version 0.0.5

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
