### PR TITLE
chore: promote nodey546 to version 1.0.20

### DIFF
--- a/config-root/namespaces/jx-staging/nodey546/nodey546-1.0.20-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-1.0.20-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-03-23T12:53:14Z"
+  creationTimestamp: "2021-03-23T12:57:44Z"
   deletionTimestamp: null
-  name: 'nodey546-1.0.19'
+  name: 'nodey546-1.0.20'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.19
-      sha: e437db4a31055971b9bfef67728a2fdf226f1ba5
+        chore: release 1.0.20
+      sha: de5ce1aefbb047b599398fbbeb171b1fc7bed922
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,11 +29,11 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 359f555694d27cede631f85b576ad10597041b86
+      sha: 4a710966042edfdd298758d46be28aad6f8ef6e7
   gitHttpUrl: https://github.com/jstrachan/nodey546
   gitOwner: jstrachan
   gitRepository: nodey546
   name: 'nodey546'
-  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.19
-  version: v1.0.19
+  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.20
+  version: v1.0.20
 status: {}

--- a/config-root/namespaces/jx-staging/nodey546/nodey546-nodey546-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-nodey546-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey546-nodey546
   labels:
     draft: draft-app
-    chart: "nodey546-1.0.19"
+    chart: "nodey546-1.0.20"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey546-nodey546
       containers:
         - name: nodey546
-          image: "gcr.io/jenkins-x-labs-bdd1/nodey546:1.0.19"
+          image: "gcr.io/jenkins-x-labs-bdd1/nodey546:1.0.20"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.19
+              value: 1.0.20
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey546/nodey546-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey546
   labels:
-    chart: "nodey546-1.0.19"
+    chart: "nodey546-1.0.20"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-lwy0h-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-lwy0h-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-ucn0s"
+  name: "jenkins-ui-test-lwy0h"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -19,7 +19,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey546
-  version: 1.0.19
+  version: 1.0.20
   name: nodey546
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey546 to version 1.0.20

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
