### PR TITLE
chore: promote nodey546 to version 1.0.25

### DIFF
--- a/config-root/namespaces/jx-staging/nodey546/nodey546-1.0.25-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-1.0.25-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-03-23T15:52:48Z"
+  creationTimestamp: "2021-03-23T16:04:31Z"
   deletionTimestamp: null
-  name: 'nodey546-1.0.23'
+  name: 'nodey546-1.0.25'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.23
-      sha: 290709c433154f5eb08f4ba496d9886f21e6d8df
+        chore: release 1.0.25
+      sha: 6ebbc5def7a15753b0e3ad41f20bb800d980d7a8
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,11 +29,11 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: d0646f8f1ccc7e15d1e7bfba8b2a5e14293b086d
+      sha: 23c1fd6beeede247122b6ef3c409bd762dda133b
   gitHttpUrl: https://github.com/jstrachan/nodey546
   gitOwner: jstrachan
   gitRepository: nodey546
   name: 'nodey546'
-  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.23
-  version: v1.0.23
+  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.25
+  version: v1.0.25
 status: {}

--- a/config-root/namespaces/jx-staging/nodey546/nodey546-nodey546-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-nodey546-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey546-nodey546
   labels:
     draft: draft-app
-    chart: "nodey546-1.0.23"
+    chart: "nodey546-1.0.25"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey546-nodey546
       containers:
         - name: nodey546
-          image: "gcr.io/jenkins-x-labs-bdd1/nodey546:1.0.23"
+          image: "gcr.io/jenkins-x-labs-bdd1/nodey546:1.0.25"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.23
+              value: 1.0.25
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey546/nodey546-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey546
   labels:
-    chart: "nodey546-1.0.23"
+    chart: "nodey546-1.0.25"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-sb65f-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-sb65f-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-op7bq"
+  name: "jenkins-ui-test-sb65f"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -19,7 +19,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey546
-  version: 1.0.23
+  version: 1.0.25
   name: nodey546
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey546 to version 1.0.25

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
