### PR TITLE
chore: promote nodey546 to version 1.0.29

### DIFF
--- a/config-root/namespaces/jx-staging/nodey546/nodey546-1.0.29-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-1.0.29-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-03-23T17:25:32Z"
+  creationTimestamp: "2021-03-23T17:29:56Z"
   deletionTimestamp: null
-  name: 'nodey546-1.0.28'
+  name: 'nodey546-1.0.29'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.28
-      sha: f513122a06869748b06d3396bce35318a3eca9c9
+        chore: release 1.0.29
+      sha: 93262f440eb1c66d6b1f25ed3bec68da2dcb19c5
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,11 +29,11 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 809707b96aab98b6c9b4d22a1d180a9b6fd48463
+      sha: c8c179d2958ed4beb4a82986390d840d29e0152b
   gitHttpUrl: https://github.com/jstrachan/nodey546
   gitOwner: jstrachan
   gitRepository: nodey546
   name: 'nodey546'
-  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.28
-  version: v1.0.28
+  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.29
+  version: v1.0.29
 status: {}

--- a/config-root/namespaces/jx-staging/nodey546/nodey546-nodey546-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-nodey546-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey546-nodey546
   labels:
     draft: draft-app
-    chart: "nodey546-1.0.28"
+    chart: "nodey546-1.0.29"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey546-nodey546
       containers:
         - name: nodey546
-          image: "gcr.io/jenkins-x-labs-bdd1/nodey546:1.0.28"
+          image: "gcr.io/jenkins-x-labs-bdd1/nodey546:1.0.29"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.28
+              value: 1.0.29
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/nodey546/nodey546-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey546
   labels:
-    chart: "nodey546-1.0.28"
+    chart: "nodey546-1.0.29"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-p3lye-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-p3lye-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-b8ywe"
+  name: "jenkins-ui-test-p3lye"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -19,7 +19,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey546
-  version: 1.0.28
+  version: 1.0.29
   name: nodey546
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey546 to version 1.0.29

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
