### PR TITLE
chore: promote nodey546 to version 1.0.31

### DIFF
--- a/config-root/namespaces/jx-staging/nodey546/nodey546-1.0.31-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-1.0.31-release.yaml
@@ -1,0 +1,48 @@
+# Source: nodey546/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-03-25T08:49:35Z"
+  deletionTimestamp: null
+  name: 'nodey546-1.0.31'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 1.0.31
+      sha: 53d093d93c02a8353e5e2dde6afd6761d1299360
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 2c567fd41df297b8b11123e5f637c631497ec2d1
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: noreply@github.com
+        name: GitHub
+      message: Update index.html
+      sha: 4f67dacc1b453ca4e357377187f5fed3679e06b1
+  gitHttpUrl: https://github.com/jstrachan/nodey546
+  gitOwner: jstrachan
+  gitRepository: nodey546
+  name: 'nodey546'
+  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.31
+  version: v1.0.31
+status: {}

--- a/config-root/namespaces/jx-staging/nodey546/nodey546-ingress.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-ingress.yaml
@@ -1,0 +1,19 @@
+# Source: nodey546/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-body-size: 1000m
+  name: nodey546
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey546
+              servicePort: 80
+      host: nodey546-jx-staging.34.89.8.12.nip.io

--- a/config-root/namespaces/jx-staging/nodey546/nodey546-nodey546-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-nodey546-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: nodey546/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodey546-nodey546
+  labels:
+    draft: draft-app
+    chart: "nodey546-1.0.31"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nodey546-nodey546
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: nodey546-nodey546
+    spec:
+      serviceAccountName: nodey546-nodey546
+      containers:
+        - name: nodey546
+          image: "gcr.io/jenkins-x-labs-bdd1/nodey546:1.0.31"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 1.0.31
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/nodey546/nodey546-nodey546-sa.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-nodey546-sa.yaml
@@ -1,0 +1,8 @@
+# Source: nodey546/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nodey546-nodey546
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/nodey546/nodey546-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey546/nodey546-svc.yaml
@@ -1,0 +1,21 @@
+# Source: nodey546/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey546
+  labels:
+    chart: "nodey546-1.0.31"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey546-nodey546

--- a/config-root/namespaces/myjenkinsa/jenkins/jenkins-agent-svc.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/jenkins-agent-svc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: myjenkinsa
   labels:
     "app.kubernetes.io/name": 'jenkins'
-    "helm.sh/chart": "jenkins-3.2.5"
+    "helm.sh/chart": "jenkins-3.3.0"
     "app.kubernetes.io/managed-by": "Helm"
     "app.kubernetes.io/instance": "jenkins"
     "app.kubernetes.io/component": "jenkins-controller"

--- a/config-root/namespaces/myjenkinsa/jenkins/jenkins-casc-reload-role.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/jenkins-casc-reload-role.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: myjenkinsa
   labels:
     "app.kubernetes.io/name": 'jenkins'
-    "helm.sh/chart": "jenkins-3.2.5"
+    "helm.sh/chart": "jenkins-3.3.0"
     "app.kubernetes.io/managed-by": "Helm"
     "app.kubernetes.io/instance": "jenkins"
     "app.kubernetes.io/component": "jenkins-controller"

--- a/config-root/namespaces/myjenkinsa/jenkins/jenkins-ingress.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/jenkins-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: myjenkinsa
   labels:
     "app.kubernetes.io/name": 'jenkins'
-    "helm.sh/chart": "jenkins-3.2.5"
+    "helm.sh/chart": "jenkins-3.3.0"
     "app.kubernetes.io/managed-by": "Helm"
     "app.kubernetes.io/instance": "jenkins"
     "app.kubernetes.io/component": "jenkins-controller"

--- a/config-root/namespaces/myjenkinsa/jenkins/jenkins-jenkins-config-jxsetup-cm.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/jenkins-jenkins-config-jxsetup-cm.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: myjenkinsa
   labels:
     "app.kubernetes.io/name": jenkins
-    "helm.sh/chart": "jenkins-3.2.5"
+    "helm.sh/chart": "jenkins-3.3.0"
     "app.kubernetes.io/managed-by": "Helm"
     "app.kubernetes.io/instance": "jenkins"
     "app.kubernetes.io/component": "jenkins-controller"

--- a/config-root/namespaces/myjenkinsa/jenkins/jenkins-jenkins-jcasc-config-cm.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/jenkins-jenkins-jcasc-config-cm.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: myjenkinsa
   labels:
     "app.kubernetes.io/name": jenkins
-    "helm.sh/chart": "jenkins-3.2.5"
+    "helm.sh/chart": "jenkins-3.3.0"
     "app.kubernetes.io/managed-by": "Helm"
     "app.kubernetes.io/instance": "jenkins"
     "app.kubernetes.io/component": "jenkins-controller"

--- a/config-root/namespaces/myjenkinsa/jenkins/jenkins-persistentvolumeclaim.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/jenkins-persistentvolumeclaim.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: myjenkinsa
   labels:
     "app.kubernetes.io/name": 'jenkins'
-    "helm.sh/chart": "jenkins-3.2.5"
+    "helm.sh/chart": "jenkins-3.3.0"
     "app.kubernetes.io/managed-by": "Helm"
     "app.kubernetes.io/instance": "jenkins"
     "app.kubernetes.io/component": "jenkins-controller"

--- a/config-root/namespaces/myjenkinsa/jenkins/jenkins-read-secrets-rb.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/jenkins-read-secrets-rb.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: myjenkinsa
   labels:
     "app.kubernetes.io/name": 'jenkins'
-    "helm.sh/chart": "jenkins-3.2.5"
+    "helm.sh/chart": "jenkins-3.3.0"
     "app.kubernetes.io/managed-by": "Helm"
     "app.kubernetes.io/instance": "jenkins"
     "app.kubernetes.io/component": "jenkins-controller"

--- a/config-root/namespaces/myjenkinsa/jenkins/jenkins-read-secrets-role.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/jenkins-read-secrets-role.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: myjenkinsa
   labels:
     "app.kubernetes.io/name": 'jenkins'
-    "helm.sh/chart": "jenkins-3.2.5"
+    "helm.sh/chart": "jenkins-3.3.0"
     "app.kubernetes.io/managed-by": "Helm"
     "app.kubernetes.io/instance": "jenkins"
     "app.kubernetes.io/component": "jenkins-controller"

--- a/config-root/namespaces/myjenkinsa/jenkins/jenkins-sa.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/jenkins-sa.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: myjenkinsa
   labels:
     "app.kubernetes.io/name": 'jenkins'
-    "helm.sh/chart": "jenkins-3.2.5"
+    "helm.sh/chart": "jenkins-3.3.0"
     "app.kubernetes.io/managed-by": "Helm"
     "app.kubernetes.io/instance": "jenkins"
     "app.kubernetes.io/component": "jenkins-controller"

--- a/config-root/namespaces/myjenkinsa/jenkins/jenkins-schedule-agents-rb.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/jenkins-schedule-agents-rb.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: myjenkinsa
   labels:
     "app.kubernetes.io/name": 'jenkins'
-    "helm.sh/chart": "jenkins-3.2.5"
+    "helm.sh/chart": "jenkins-3.3.0"
     "app.kubernetes.io/managed-by": "Helm"
     "app.kubernetes.io/instance": "jenkins"
     "app.kubernetes.io/component": "jenkins-controller"

--- a/config-root/namespaces/myjenkinsa/jenkins/jenkins-schedule-agents-role.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/jenkins-schedule-agents-role.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: myjenkinsa
   labels:
     "app.kubernetes.io/name": 'jenkins'
-    "helm.sh/chart": "jenkins-3.2.5"
+    "helm.sh/chart": "jenkins-3.3.0"
     "app.kubernetes.io/managed-by": "Helm"
     "app.kubernetes.io/instance": "jenkins"
     "app.kubernetes.io/component": "jenkins-controller"

--- a/config-root/namespaces/myjenkinsa/jenkins/jenkins-secret.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/jenkins-secret.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: myjenkinsa
   labels:
     "app.kubernetes.io/name": 'jenkins'
-    "helm.sh/chart": "jenkins-3.2.5"
+    "helm.sh/chart": "jenkins-3.3.0"
     "app.kubernetes.io/managed-by": "Helm"
     "app.kubernetes.io/instance": "jenkins"
     "app.kubernetes.io/component": "jenkins-controller"
@@ -29,7 +29,7 @@ spec:
     metadata:
       labels:
         "app.kubernetes.io/name": 'jenkins'
-        "helm.sh/chart": "jenkins-3.2.5"
+        "helm.sh/chart": "jenkins-3.3.0"
         "app.kubernetes.io/managed-by": "Helm"
         "app.kubernetes.io/instance": "jenkins"
         "app.kubernetes.io/component": "jenkins-controller"

--- a/config-root/namespaces/myjenkinsa/jenkins/jenkins-statefulset.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/jenkins-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: myjenkinsa
   labels:
     "app.kubernetes.io/name": 'jenkins'
-    "helm.sh/chart": "jenkins-3.2.5"
+    "helm.sh/chart": "jenkins-3.3.0"
     "app.kubernetes.io/managed-by": "Helm"
     "app.kubernetes.io/instance": "jenkins"
     "app.kubernetes.io/component": "jenkins-controller"
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: "jenkins"
       initContainers:
         - name: "init"
-          image: "jenkins/jenkins:2.277.1"
+          image: "jenkins/jenkins:2.277.1-jdk11"
           imagePullPolicy: "Always"
           command: ["sh", "/var/jenkins_config/apply_config.sh"]
           resources:
@@ -56,7 +56,7 @@ spec:
               name: plugin-dir
       containers:
         - name: jenkins
-          image: "jenkins/jenkins:2.277.1"
+          image: "jenkins/jenkins:2.277.1-jdk11"
           imagePullPolicy: "Always"
           args: ["--httpPort=8080"]
           env:

--- a/config-root/namespaces/myjenkinsa/jenkins/jenkins-svc.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/jenkins-svc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: myjenkinsa
   labels:
     "app.kubernetes.io/name": 'jenkins'
-    "helm.sh/chart": "jenkins-3.2.5"
+    "helm.sh/chart": "jenkins-3.3.0"
     "app.kubernetes.io/managed-by": "Helm"
     "app.kubernetes.io/instance": "jenkins"
     "app.kubernetes.io/component": "jenkins-controller"

--- a/config-root/namespaces/myjenkinsa/jenkins/jenkins-watch-configmaps-rb.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/jenkins-watch-configmaps-rb.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: myjenkinsa
   labels:
     "app.kubernetes.io/name": 'jenkins'
-    "helm.sh/chart": "jenkins-3.2.5"
+    "helm.sh/chart": "jenkins-3.3.0"
     "app.kubernetes.io/managed-by": "Helm"
     "app.kubernetes.io/instance": "jenkins"
     "app.kubernetes.io/component": "jenkins-controller"

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-hjf5c-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-hjf5c-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-s5rjm"
+  name: "jenkins-ui-test-hjf5c"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success
@@ -25,7 +25,7 @@ spec:
           name: tools
   containers:
     - name: jenkins-ui-test
-      image: jenkins/jenkins:2.277.1
+      image: jenkins/jenkins:2.277.1-jdk11
       command: ["/tools/bats/bin/bats", "-t", "/tests/run.sh"]
       volumeMounts:
         - mountPath: /tests

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -4,5 +4,12 @@ environments:
     values:
     - jx-values.yaml
 namespace: jx-staging
+repositories:
+- name: dev
+  url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
+releases:
+- chart: dev/nodey546
+  version: 1.0.31
+  name: nodey546
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -11,5 +11,7 @@ releases:
 - chart: dev/nodey546
   version: 1.0.31
   name: nodey546
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey546 to version 1.0.31

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
