### PR TITLE
chore: promote nodey560 to version 0.0.7

### DIFF
--- a/config-root/namespaces/jx-staging/nodey560/nodey560-0.0.7-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey560/nodey560-0.0.7-release.yaml
@@ -1,0 +1,48 @@
+# Source: nodey560/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-03-26T11:43:59Z"
+  deletionTimestamp: null
+  name: 'nodey560-0.0.7'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.7
+      sha: a7c7cf1cab010e97bd0afcde2357d5f1c9c091f2
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: d60958e9894d45c143a5b487dfbd6e7c7d7e69b1
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: noreply@github.com
+        name: GitHub
+      message: Update index.html
+      sha: f9792cfcf148845f23a2d6dda816cbd93cfa15d9
+  gitHttpUrl: https://github.com/jstrachan/nodey560
+  gitOwner: jstrachan
+  gitRepository: nodey560
+  name: 'nodey560'
+  releaseNotesURL: https://github.com/jstrachan/nodey560/releases/tag/v0.0.7
+  version: v0.0.7
+status: {}

--- a/config-root/namespaces/jx-staging/nodey560/nodey560-ingress.yaml
+++ b/config-root/namespaces/jx-staging/nodey560/nodey560-ingress.yaml
@@ -1,0 +1,19 @@
+# Source: nodey560/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-body-size: 1000m
+  name: nodey560
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey560
+              servicePort: 80
+      host: nodey560-jx-staging.34.89.8.12.nip.io

--- a/config-root/namespaces/jx-staging/nodey560/nodey560-nodey560-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey560/nodey560-nodey560-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: nodey560/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodey560-nodey560
+  labels:
+    draft: draft-app
+    chart: "nodey560-0.0.7"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nodey560-nodey560
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: nodey560-nodey560
+    spec:
+      serviceAccountName: nodey560-nodey560
+      containers:
+        - name: nodey560
+          image: "gcr.io/jenkins-x-labs-bdd1/nodey560:0.0.7"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.7
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/nodey560/nodey560-nodey560-sa.yaml
+++ b/config-root/namespaces/jx-staging/nodey560/nodey560-nodey560-sa.yaml
@@ -1,0 +1,8 @@
+# Source: nodey560/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nodey560-nodey560
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/nodey560/nodey560-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey560/nodey560-svc.yaml
@@ -1,0 +1,18 @@
+# Source: nodey560/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey560
+  labels:
+    chart: "nodey560-0.0.7"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey560-nodey560

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-r3bor-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-r3bor-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-qbe8s"
+  name: "jenkins-ui-test-r3bor"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -4,5 +4,12 @@ environments:
     values:
     - jx-values.yaml
 namespace: jx-staging
+repositories:
+- name: dev
+  url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
+releases:
+- chart: dev/nodey560
+  version: 0.0.7
+  name: nodey560
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -11,5 +11,7 @@ releases:
 - chart: dev/nodey560
   version: 0.0.7
   name: nodey560
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey560 to version 0.0.7

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
