### PR TITLE
chore: promote nodey560 to version 0.0.11

### DIFF
--- a/config-root/namespaces/jx-staging/nodey560/nodey560-0.0.11-release.yaml
+++ b/config-root/namespaces/jx-staging/nodey560/nodey560-0.0.11-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-03-26T12:08:16Z"
+  creationTimestamp: "2021-03-26T12:20:27Z"
   deletionTimestamp: null
-  name: 'nodey560-0.0.10'
+  name: 'nodey560-0.0.11'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.10
-      sha: bd512b7d041c6598979e1e6302af41d45363b1ea
+        chore: release 0.0.11
+      sha: a4f931cc282386169d6a0712f1599353cbb46ac2
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: ba156e5df6ae8401bc2a9c9330f008348ef10d8d
+      sha: 69311cf22c38c53b2e464f26da19948475d6546b
     - author:
         email: james.strachan@gmail.com
         name: James Strachan
@@ -38,11 +38,11 @@ spec:
         email: noreply@github.com
         name: GitHub
       message: Update index.html
-      sha: 7fd234a6d81b63eab7b916cc73be29cd33d2ad4f
+      sha: ff8f3b7949972fdecb3adca4b3f7cf2906c60eb2
   gitHttpUrl: https://github.com/jstrachan/nodey560
   gitOwner: jstrachan
   gitRepository: nodey560
   name: 'nodey560'
-  releaseNotesURL: https://github.com/jstrachan/nodey560/releases/tag/v0.0.10
-  version: v0.0.10
+  releaseNotesURL: https://github.com/jstrachan/nodey560/releases/tag/v0.0.11
+  version: v0.0.11
 status: {}

--- a/config-root/namespaces/jx-staging/nodey560/nodey560-nodey560-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey560/nodey560-nodey560-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey560-nodey560
   labels:
     draft: draft-app
-    chart: "nodey560-0.0.10"
+    chart: "nodey560-0.0.11"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey560-nodey560
       containers:
         - name: nodey560
-          image: "gcr.io/jenkins-x-labs-bdd1/nodey560:0.0.10"
+          image: "gcr.io/jenkins-x-labs-bdd1/nodey560:0.0.11"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.10
+              value: 0.0.11
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/nodey560/nodey560-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey560/nodey560-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey560
   labels:
-    chart: "nodey560-0.0.10"
+    chart: "nodey560-0.0.11"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
 spec:

--- a/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-o6vfa-pod.yaml
+++ b/config-root/namespaces/myjenkinsa/jenkins/templates/tests/jenkins-ui-test-o6vfa-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-xsx9h"
+  name: "jenkins-ui-test-o6vfa"
   namespace: myjenkinsa
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
 releases:
 - chart: dev/nodey560
-  version: 0.0.10
+  version: 0.0.11
   name: nodey560
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey560 to version 0.0.11

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
