### PR TITLE
chore: promote nodey560 to version 1.0.4

### DIFF
--- a/config-root/namespaces/jx-staging/nodey560/nodey560-nodey560-deploy.yaml
+++ b/config-root/namespaces/jx-staging/nodey560/nodey560-nodey560-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey560-nodey560
   labels:
     draft: draft-app
-    chart: "nodey560-1.0.1"
+    chart: "nodey560-1.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey560-nodey560
       containers:
         - name: nodey560
-          image: "gcr.io/jenkins-x-labs-bdd1/nodey560:1.0.1"
+          image: "gcr.io/jenkins-x-labs-bdd1/nodey560:1.0.4"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.1
+              value: 1.0.4
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/nodey560/nodey560-svc.yaml
+++ b/config-root/namespaces/jx-staging/nodey560/nodey560-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey560
   labels:
-    chart: "nodey560-1.0.1"
+    chart: "nodey560-1.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
 spec:

--- a/config-root/namespaces/myjenkinsd/jenkins/templates/tests/jenkins-ui-test-qsh5y-pod.yaml
+++ b/config-root/namespaces/myjenkinsd/jenkins/templates/tests/jenkins-ui-test-qsh5y-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-fnwee"
+  name: "jenkins-ui-test-qsh5y"
   namespace: myjenkinsd
   annotations:
     "helm.sh/hook": test-success

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@
 		    </tr>
 	    <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> nodey560 </a></td>
-	      <td>1.0.1</td>
+	      <td>1.0.4</td>
 	      <td><a href='http://nodey560-jx-staging.34.89.8.12.nip.io'>view</a></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -36,7 +36,7 @@
     repositoryName: dev
     repositoryUrl: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
     resourcePath: config-root/namespaces/jx-staging/nodey560
-    version: 1.0.1
+    version: 1.0.4
   - apiVersion: v1
     applicationUrl: http://nodey546-jx-staging.34.89.8.12.nip.io
     description: A Helm chart for Kubernetes

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -11,7 +11,7 @@ repositories:
   url: http://chartmuseum-jx.34.89.8.12.nip.io/
 releases:
 - chart: dev/nodey560
-  version: 1.0.1
+  version: 1.0.4
   name: nodey560
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey560 to version 1.0.4

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
